### PR TITLE
Redefining baseDN from domain name instead of KDC

### DIFF
--- a/cme/protocols/ldap.py
+++ b/cme/protocols/ldap.py
@@ -215,7 +215,7 @@ class ldap(connection):
 
         # Create the baseDN
         self.baseDN = ''
-        domainParts = self.kdcHost.split('.')
+        domainParts = self.domain.split('.')
         for i in domainParts:
             self.baseDN += 'dc=%s,' % i
         # Remove last ','
@@ -305,7 +305,7 @@ class ldap(connection):
 
         # Create the baseDN
         self.baseDN = ''
-        domainParts = self.kdcHost.split('.')
+        domainParts = self.domain.split('.')
         for i in domainParts:
             self.baseDN += 'dc=%s,' % i
         # Remove last ','


### PR DESCRIPTION
Hey there, this small PR fixes the baseDN calculation for the ldap protocol. Currently, it's based on a split of the value provided for the KDC with the `--kdcHost` argument. Actually it should be based on the domain name either supplied with the `-d` argument or automatically fetched by CME. 
This also fixes the bugs some could face when trying to use CME with LDAP with kdcHost set to its IP address instead of its hostname (usually done when facing a foreign domain or when the DNS configuration is not correctly pushed through DHCP).