### PR TITLE
whoami LDAP module

### DIFF
--- a/cme/modules/whoami.py
+++ b/cme/modules/whoami.py
@@ -2,18 +2,18 @@ from ldap3 import Server, Connection, NTLM, ALL
 
 class CMEModule:
     '''
-        Sanity check of current user groups and privileges 
+        Basic enumeration of provided user information and privileges 
         Module by spyr0 (@spyr0-sec)
     '''
     name = 'whoami'
-    description = 'Get privileges of provided user'
+    description = 'Get details of provided user'
     supported_protocols = ['ldap']
     opsec_safe = True #Does the module touch disk?
     multiple_hosts = True # Does it make sense to run this module on multiple hosts at a time?
 
     def options(self, context, module_options):
         '''
-            No options required
+            No options requireds
         '''
         pass
 
@@ -44,7 +44,7 @@ class CMEModule:
             for response in ldapConn.response:
                 context.log.highlight(f"Distinguished name: {response['attributes']['distinguishedName']}")
                 context.log.highlight(f"Human name: {response['attributes']['name']}")
-                context.log.highlight(f"Description: {response['attributes']['description'][0]}")
+                context.log.highlight(f"Description: {response['attributes']['description']}")
                 context.log.highlight(f"Password last set: {response['attributes']['pwdLastSet']}")
 
                 for group in response['attributes']['memberOf']:

--- a/cme/modules/whoami.py
+++ b/cme/modules/whoami.py
@@ -46,7 +46,7 @@ class CMEModule:
 
             # Get attributes of provided user
             ldapConn.search(search_base=searchBase,search_filter=searchFilter,
-            attributes=['name','sAmAccountName','description','distinguishedName','pwdLastSet','logonCount','lastLogon','userAccountControl','memberOf'])      
+            attributes=['name','sAmAccountName','description','distinguishedName','pwdLastSet','logonCount','lastLogon','userAccountControl','servicePrincipalName','memberOf'])      
 
             for response in ldapConn.response:
                 context.log.highlight(f"Human name: {response['attributes']['name']}")
@@ -68,8 +68,13 @@ class CMEModule:
                     context.log.highlight(f"Password Never Expires: Yes")
                 if response['attributes']['userAccountControl'] == 66050:
                     context.log.highlight(f"Enabled: No")
-                    context.log.highlight(f"Password Never Expires: Yes")                
+                    context.log.highlight(f"Password Never Expires: Yes")
 
+                if len(response['attributes']['servicePrincipalName']) != 0:
+                    context.log.highlight(f"Service Account Name(s) found - Potentially Kerberoastable user!")
+                    for spn in response['attributes']['servicePrincipalName']:
+                        context.log.highlight(f"Service Account Name: {spn}")
+                              
                 for group in response['attributes']['memberOf']:
                     context.log.highlight(f'Member of: {group}')
 

--- a/cme/modules/whoami.py
+++ b/cme/modules/whoami.py
@@ -55,7 +55,11 @@ class CMEModule:
                 context.log.highlight(f"Distinguished name: {response['attributes']['distinguishedName']}")
                 context.log.highlight(f"Password last set: {response['attributes']['pwdLastSet']}")
                 context.log.highlight(f"Logon count: {response['attributes']['logonCount']}")
-                context.log.highlight(f"Last logon: {response['attributes']['lastLogon']}")
+
+                if '1601' in str(response['attributes']['lastLogon']):
+                    context.log.highlight(f"Last logon: Never")
+                else:
+                    context.log.highlight(f"Last logon: {response['attributes']['lastLogon']}")
 
                 if response['attributes']['userAccountControl'] == 512:
                     context.log.highlight(f"Enabled: Yes")

--- a/cme/modules/whoami.py
+++ b/cme/modules/whoami.py
@@ -20,20 +20,7 @@ class CMEModule:
                 self.username = module_options['USER']
 
     def on_login(self, context, connection):
-
-        # Grab the variables from the CME connection to fill our variables
-        inputUser = connection.domain + '\\' + connection.username
-        inputPassword = connection.password
-        dcTarget = connection.conn.getRemoteHost()
-
-        try:
-            # Connect and bind to the LDAP server
-            ldapServer = Server(dcTarget, use_ssl=False, port=389, get_info=ALL)
-            ldapConn = Connection(ldapServer, user=inputUser, password=inputPassword, authentication=NTLM, auto_bind=True)
-
-            # https://github.com/pycontribs/python3-ldap/blob/master/python3-ldap/ldap3/protocol/rfc4512.py
-            searchBase = ldapServer.info.naming_contexts[0]
-
+            searchBase = connection.ldapConnection._baseDN
             if self.username is None:
                 searchFilter = f'(sAMAccountName={connection.username})'
             else:
@@ -41,52 +28,40 @@ class CMEModule:
                 
             context.log.debug(f'Using naming context: {searchBase} and {searchFilter} as search filter')
 
-            # Confirm login / get username
-            context.log.debug(f'Running LDAP queries as: {ldapConn.extend.standard.who_am_i().replace("u:","")}')
-
             # Get attributes of provided user
-            ldapConn.search(search_base=searchBase,search_filter=searchFilter,
-            attributes=['name','sAmAccountName','description','distinguishedName','pwdLastSet','logonCount','lastLogon','userAccountControl','servicePrincipalName','memberOf'])      
+            r = connection.ldapConnection.search(
+                searchBase=searchBase,
+                searchFilter=searchFilter,
+                attributes=['name','sAmAccountName','description','distinguishedName','pwdLastSet','logonCount','lastLogon','userAccountControl','servicePrincipalName','memberOf'],
+                sizeLimit=999
 
-            for response in ldapConn.response:
-                context.log.highlight(f"Human name: {response['attributes']['name']}")
-                context.log.highlight(f"Username: {response['attributes']['sAmAccountName']}")
-                context.log.highlight(f"Description: {response['attributes']['description']}")
-                context.log.highlight(f"Distinguished name: {response['attributes']['distinguishedName']}")
-                context.log.highlight(f"Password last set: {response['attributes']['pwdLastSet']}")
-                context.log.highlight(f"Logon count: {response['attributes']['logonCount']}")
-
-                if '1601' in str(response['attributes']['lastLogon']):
-                    context.log.highlight(f"Last logon: Never")
-                else:
-                    context.log.highlight(f"Last logon: {response['attributes']['lastLogon']}")
-
-                if response['attributes']['userAccountControl'] == 512:
-                    context.log.highlight(f"Enabled: Yes")
-                    context.log.highlight(f"Password Never Expires: No")
-                if response['attributes']['userAccountControl'] == 514:
-                    context.log.highlight(f"Enabled: No")
-                    context.log.highlight(f"Password Never Expires: No")                    
-                if response['attributes']['userAccountControl'] == 66048:
-                    context.log.highlight(f"Enabled: Yes")
-                    context.log.highlight(f"Password Never Expires: Yes")
-                if response['attributes']['userAccountControl'] == 66050:
-                    context.log.highlight(f"Enabled: No")
-                    context.log.highlight(f"Password Never Expires: Yes")
-
-                if len(response['attributes']['servicePrincipalName']) != 0:
+            )
+            for response in r[0]['attributes']:
+                if 'userAccountControl' in str(response['type']):
+                    if str(response['vals'][0]) == "512":
+                        context.log.highlight(f"Enabled: Yes")
+                        context.log.highlight(f"Password Never Expires: No")
+                    elif str(response['vals'][0]) == "514":
+                        context.log.highlight(f"Enabled: No")
+                        context.log.highlight(f"Password Never Expires: No")
+                    elif str(response['vals'][0]) == "66048":
+                        context.log.highlight(f"Enabled: Yes")
+                        context.log.highlight(f"Password Never Expires: Yes")
+                    elif str(response['vals'][0]) == "66050":
+                        context.log.highlight(f"Enabled: No")
+                        context.log.highlight(f"Password Never Expires: Yes")
+                elif 'lastLogon' in str(response['type']):
+                    if str(response['vals'][0]) == "1601":
+                        context.log.highlight(f"Last logon: Never")
+                    else:
+                        context.log.highlight(f"Last logon: {response['vals'][0]}")
+                elif 'memberOf' in str(response['type']):
+                    for group in response['vals']:
+                        context.log.highlight(f'Member of: {group}')
+                elif 'servicePrincipalName' in str(response['type']):
                     context.log.highlight(f"Service Account Name(s) found - Potentially Kerberoastable user!")
-                    for spn in response['attributes']['servicePrincipalName']:
+                    for spn in response['vals']:
                         context.log.highlight(f"Service Account Name: {spn}")
-                              
-                for group in response['attributes']['memberOf']:
-                    context.log.highlight(f'Member of: {group}')
+                else:
+                    context.log.highlight(response['type'] + ": " +  response['vals'][0])
 
-                # Only want output from first response
-                break
-        
-        except KeyError:
-            context.log.error(f'Username does not exist')
-
-        except Exception as e:
-            context.log.error(f'UNEXPECTED ERROR: {repr(e)}')

--- a/cme/modules/whoami.py
+++ b/cme/modules/whoami.py
@@ -1,0 +1,57 @@
+from ldap3 import Server, Connection, NTLM, ALL
+
+class CMEModule:
+    '''
+        Sanity check of current user groups and privileges 
+        Module by spyr0 (@spyr0-sec)
+    '''
+    name = 'whoami'
+    description = 'Get privileges of provided user'
+    supported_protocols = ['ldap']
+    opsec_safe = True #Does the module touch disk?
+    multiple_hosts = True # Does it make sense to run this module on multiple hosts at a time?
+
+    def options(self, context, module_options):
+        '''
+            No options required
+        '''
+        pass
+
+    def on_login(self, context, connection):
+
+        # Grab the variables from the CME connection to fill our variables
+        inputUser = connection.domain + '\\' + connection.username
+        inputPassword = connection.password
+        dcTarget = connection.conn.getRemoteHost()
+
+        try:
+            # Connect and bind to the LDAP server
+            ldapServer = Server(dcTarget, use_ssl=False, port=389, get_info=ALL)
+            ldapConn = Connection(ldapServer, user=inputUser, password=inputPassword, authentication=NTLM, auto_bind=True)
+
+            # https://github.com/pycontribs/python3-ldap/blob/master/python3-ldap/ldap3/protocol/rfc4512.py
+            searchBase = ldapServer.info.naming_contexts[0]
+            searchFilter = f'(sAMAccountName={connection.username})'
+
+            context.log.debug(f'Using naming context: {searchBase} and {searchFilter} as search filter')
+
+            # Confirm login / get username
+            context.log.highlight(f'Username: {ldapConn.extend.standard.who_am_i().replace("u:","")}')
+
+            # Get attributes of provided user
+            ldapConn.search(search_base=searchBase,search_filter=searchFilter,attributes=['description','distinguishedName', 'memberOf', 'name', 'pwdLastSet'])      
+
+            for response in ldapConn.response:
+                context.log.highlight(f"Distinguished name: {response['attributes']['distinguishedName']}")
+                context.log.highlight(f"Human name: {response['attributes']['name']}")
+                context.log.highlight(f"Description: {response['attributes']['description'][0]}")
+                context.log.highlight(f"Password last set: {response['attributes']['pwdLastSet']}")
+
+                for group in response['attributes']['memberOf']:
+                    context.log.highlight(f'Member of: {group}')
+
+                # Only want output from first response
+                break
+        
+        except Exception as e:
+            context.log.error(f'UNEXPECTED ERROR: {e}')

--- a/cme/modules/whoami.py
+++ b/cme/modules/whoami.py
@@ -13,9 +13,11 @@ class CMEModule:
 
     def options(self, context, module_options):
         '''
-            No options requireds
+            USER  Enumerate information about a different SamAccountName
         '''
-        pass
+        self.username = None
+        if 'USER' in module_options:
+                self.username = module_options['USER']
 
     def on_login(self, context, connection):
 
@@ -31,21 +33,42 @@ class CMEModule:
 
             # https://github.com/pycontribs/python3-ldap/blob/master/python3-ldap/ldap3/protocol/rfc4512.py
             searchBase = ldapServer.info.naming_contexts[0]
-            searchFilter = f'(sAMAccountName={connection.username})'
 
+            if self.username is None:
+                searchFilter = f'(sAMAccountName={connection.username})'
+            else:
+                searchFilter = f'(sAMAccountName={format(self.username)})'
+                
             context.log.debug(f'Using naming context: {searchBase} and {searchFilter} as search filter')
 
             # Confirm login / get username
-            context.log.highlight(f'Username: {ldapConn.extend.standard.who_am_i().replace("u:","")}')
+            context.log.debug(f'Running LDAP queries as: {ldapConn.extend.standard.who_am_i().replace("u:","")}')
 
             # Get attributes of provided user
-            ldapConn.search(search_base=searchBase,search_filter=searchFilter,attributes=['description','distinguishedName', 'memberOf', 'name', 'pwdLastSet'])      
+            ldapConn.search(search_base=searchBase,search_filter=searchFilter,
+            attributes=['name','sAmAccountName','description','distinguishedName','pwdLastSet','logonCount','lastLogon','userAccountControl','memberOf'])      
 
             for response in ldapConn.response:
-                context.log.highlight(f"Distinguished name: {response['attributes']['distinguishedName']}")
                 context.log.highlight(f"Human name: {response['attributes']['name']}")
+                context.log.highlight(f"Username: {response['attributes']['sAmAccountName']}")
                 context.log.highlight(f"Description: {response['attributes']['description']}")
+                context.log.highlight(f"Distinguished name: {response['attributes']['distinguishedName']}")
                 context.log.highlight(f"Password last set: {response['attributes']['pwdLastSet']}")
+                context.log.highlight(f"Logon count: {response['attributes']['logonCount']}")
+                context.log.highlight(f"Last logon: {response['attributes']['lastLogon']}")
+
+                if response['attributes']['userAccountControl'] == 512:
+                    context.log.highlight(f"Enabled: Yes")
+                    context.log.highlight(f"Password Never Expires: No")
+                if response['attributes']['userAccountControl'] == 514:
+                    context.log.highlight(f"Enabled: No")
+                    context.log.highlight(f"Password Never Expires: No")                    
+                if response['attributes']['userAccountControl'] == 66048:
+                    context.log.highlight(f"Enabled: Yes")
+                    context.log.highlight(f"Password Never Expires: Yes")
+                if response['attributes']['userAccountControl'] == 66050:
+                    context.log.highlight(f"Enabled: No")
+                    context.log.highlight(f"Password Never Expires: Yes")                
 
                 for group in response['attributes']['memberOf']:
                     context.log.highlight(f'Member of: {group}')
@@ -53,5 +76,8 @@ class CMEModule:
                 # Only want output from first response
                 break
         
+        except KeyError:
+            context.log.error(f'Username does not exist')
+
         except Exception as e:
-            context.log.error(f'UNEXPECTED ERROR: {e}')
+            context.log.error(f'UNEXPECTED ERROR: {repr(e)}')


### PR DESCRIPTION
Simple 'whoami' type module for LDAP, handy for when you compromise a user and want information regarding the account quickly. The module performs a search for the sAMAccountName via a LDAP query and outputs the following:

User / Human / Distinguished name
Description
Password last set / Logon count / Last logon timestamp / Password never expires
Enabled status
Any ServicePrincipalNames associated
Each group the user is a member of

Command to run:
poetry run crackmapexec ldap \<IP\> -u \<USER\> -p \<PASS\> -M whoami [-o USER=\<SAMACCOUNTNAME\>]

![image](https://user-images.githubusercontent.com/78267628/184109259-c9f38108-7a06-4dde-a595-74443e0ea1ec.png)

