### PR TITLE
Module to check for NTLMv1 Compatibility

### DIFF
--- a/cme/modules/ntlmv1.py
+++ b/cme/modules/ntlmv1.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from impacket.dcerpc.v5 import rrp
+from impacket.examples.secretsdump import RemoteOperations
+from impacket.dcerpc.v5.rrp import DCERPCSessionError
+
+class CMEModule:
+    '''
+    Detect if the targets's LmCompatibilityLevel will allow NTLMv1 authentication
+    Module by @Tw1sm
+    '''
+    name = 'ntlmv1'
+    description = 'Detect if lmcompatibilitylevel on the target is set to 0 or 1'
+    supported_protocols = ['smb']
+    opsec_safe= True
+    multiple_hosts = True
+
+    def options(self, context, module_options):
+        self.output = 'NTLMv1 allowed on: {} - LmCompatibilityLevel = {}'
+
+    def on_admin_login(self, context, connection):
+        try:
+            remoteOps = RemoteOperations(connection.conn, False)
+            remoteOps.enableRegistry()
+
+            if remoteOps._RemoteOperations__rrp:
+                ans = rrp.hOpenLocalMachine(remoteOps._RemoteOperations__rrp)
+                regHandle = ans['phKey']
+
+                ans = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, 'SYSTEM\\CurrentControlSet\\Control\\Lsa')
+                keyHandle = ans['phkResult']
+
+                rtype, data = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, 'lmcompatibilitylevel\x00')
+
+                if int(data) in [0, 1]:
+                    context.log.highlight(self.output.format(connection.conn.getRemoteHost(), data))
+
+            try:
+                remoteOps.finish()
+            except:
+                pass
+
+        except DCERPCSessionError as e:
+            try:
+                remoteOps.finish()
+            except:
+                pass

--- a/cme/modules/ntlmv1.py
+++ b/cme/modules/ntlmv1.py
@@ -33,7 +33,7 @@ class CMEModule:
 
                 rtype, data = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, 'lmcompatibilitylevel\x00')
 
-                if int(data) in [0, 1]:
+                if int(data) in [0, 1, 2]:
                     context.log.highlight(self.output.format(connection.conn.getRemoteHost(), data))
 
             try:


### PR DESCRIPTION
Added a small module to query the target's `LmCompatibilityLevel` to determine if the target allows NTLMv1 auth. 

Example:
<img width="1073" alt="image" src="https://user-images.githubusercontent.com/37981031/190522507-adfc8d2a-b69e-472b-a447-e7975ce3ba94.png">

This check queries the registry which requires admin privileges - makes it more ideal for auditing systems that still allow NTLMv1 than locating boxes you can laterally move to (unfortunately)