### PR TITLE
Fix logging with LDAPS protocol

### DIFF
--- a/cme/protocols/ldap.py
+++ b/cme/protocols/ldap.py
@@ -254,16 +254,17 @@ class ldap(connection):
                     hash_asreproast.write(hash_TGT + '\n')
             return False
 
+        # Prepare success credential text
+        out = u'{}{}:{} {}'.format('{}\\'.format(domain),
+                                            username,
+                                            password if not self.config.get('CME', 'audit_mode') else self.config.get('CME', 'audit_mode')*8,
+                                            highlight('({})'.format(self.config.get('CME', 'pwn3d_label')) if self.admin_privs else ''))
         try:
+            # Connect to LDAP
             self.ldapConnection = ldap_impacket.LDAPConnection('ldap://%s' % target, self.baseDN, self.kdcHost)
             self.ldapConnection.login(self.username, self.password, self.domain, self.lmhash, self.nthash)
             self.check_if_admin()
 
-            # Connect to LDAP
-            out = u'{}{}:{} {}'.format('{}\\'.format(domain),
-                                                username,
-                                                password if not self.config.get('CME', 'audit_mode') else self.config.get('CME', 'audit_mode')*8,
-                                                highlight('({})'.format(self.config.get('CME', 'pwn3d_label')) if self.admin_privs else ''))
             self.logger.extra['protocol'] = "LDAP"
             self.logger.extra['port'] = "389"
             self.logger.success(out)


### PR DESCRIPTION
When attempting to connect to a windows server 2022, i got this error:
![image](https://user-images.githubusercontent.com/10145128/190678708-4e4116d0-2671-4042-b968-c51b1e5d91c5.png)

Because the out text variable was define in the try bloc after the ldap login success, so later after a successful login in LDAPS except bloc, this var was not define.

Here is a quick fix to define this variable earlier and provide the text no matter which protocol is used.