### PR TITLE
LDAP protocol improvements and scan-network module bugfix

### DIFF
--- a/cme/modules/scan-network.py
+++ b/cme/modules/scan-network.py
@@ -39,7 +39,7 @@ def get_dns_resolver(server, context):
     return dnsresolver
 
 def ldap2domain(ldap):
-    return re.sub(',DC=', '.', ldap[ldap.find('dc='):], flags=re.I)[3:]
+    return re.sub(',DC=', '.', ldap[ldap.lower().find('dc='):], flags=re.I)[3:]
 
 def new_record(rtype, serial):
     nr = DNS_RECORD()

--- a/cme/protocols/ldap.py
+++ b/cme/protocols/ldap.py
@@ -108,7 +108,7 @@ class ldap(connection):
                     logging.debug("Exception:", exc_info=True)
                     logging.debug('Skipping item, cannot process due to error %s' % str(e))
         except OSError as e:
-                self.logger.error(u'Error connecting to the host.')
+            self.logger.error(u'Error connecting to the host.')
 
         return '' 
 


### PR DESCRIPTION
In this pull request I tried fixing some LDAP related issues. 

# Changes
cme/protocols/ldap.py:
- When the --no-smb is provided, automatic domain lookup is disabled and --domain should be provided.
- The LDAP module uses the kdchost or domain parameter to resolve the target ldap server(s?!), instead of designated host parameter. I restored the use of the host parameter as the ldap server
- The baseDN is generated using the kdchost or domain parameter, depending on the login function (kerberos_login/ plaintext_login/hash_login), which does not make sense. For example when the kdchost points to an actual DC (e.g. dc01.test.com), this results in the invalid baseDN dc=test,dc=test,dc=com. Additionally, using the domain parameter result would result in an incorrect baseDN  during cross domain/forest authentication where user domain != target domain. I added twp additional methods to resolve the baseDN: 1. the baseDN parameter and 2. anonymous LDAP lookup to resolve the baseDN. 
- During kerberos login the self.username variable is never defined, this can cause issues in other places (e.g. the new [whoami](https://github.com/Porchetta-Industries/CrackMapExec/blob/master/cme/modules/whoami.py#L25) module). I implemented the ldap whoami request to retrieve the username after succesfull kerberos authentication.

cme/modules/scan-network.py:
- The ldap2domain function does not check if the prodived DN is lowercase when searching for "dc=".

Other notes that are not (yet?) addressed:
- Should the ldap module really implement the --local-auth parameter?
- The ports parameter is not used
- The kdcHost parameter fails to perform kerberos when using the domain name(e.g. test.com), this is due to the fact that the ldap/test.com spn does not exist. Should a (random) domain controller be selected (using DNS lookups?) based on the kdchost value?