### PR TITLE
Improved cmedb export function

### DIFF
--- a/cme/cmedb.py
+++ b/cme/cmedb.py
@@ -74,11 +74,11 @@ class DatabaseNavigator(cmd.Cmd):
                 for cred in creds:
                     entry = []
                     
-                    entry.append(cred[0])
-                    entry.append(cred[1])
-                    entry.append(cred[2])
-                    entry.append(cred[3])
-                    entry.append(cred[4])
+                    entry.append(cred[0]) # ID
+                    entry.append(cred[1]) # Domain
+                    entry.append(cred[2]) # Username
+                    entry.append(cred[3]) # Password/Hash
+                    entry.append(cred[4]) # Cred Type
                     
                     
                     if cred[5] == "":

--- a/cme/cmedb.py
+++ b/cme/cmedb.py
@@ -81,7 +81,7 @@ class DatabaseNavigator(cmd.Cmd):
                     entry.append(cred[3]) # Password/Hash
                     entry.append(cred[4]) # Cred Type
                     
-                    print(cred[5])
+                    
                     if cred[5] == None:
                         entry.append("")
                     else:

--- a/cme/cmedb.py
+++ b/cme/cmedb.py
@@ -116,7 +116,7 @@ class DatabaseNavigator(cmd.Cmd):
                 return
             
             shares = self.db.get_shares()
-            csv_header = ["id","computerid","userid","name","remark","read","write"]
+            csv_header = ["id","computer","userid","name","remark","read","write"]
             filename = line[2]
             
             if line[1].lower() == 'simple':
@@ -132,7 +132,7 @@ class DatabaseNavigator(cmd.Cmd):
                     #shareID
                     entry.append(share[0])
                     
-                    #computerID
+                    #computer
                     entry.append(self.db.get_computers(share[1])[0][2])
                     
                     #userID
@@ -172,7 +172,7 @@ class DatabaseNavigator(cmd.Cmd):
 
             # These Values don't change between simple and detailed
             local_admins = self.db.get_admin_relations()
-            csv_header = ["id","userid","computerid"]
+            csv_header = ["id","userid","computer"]
             filename = line[2]
             
             if line[1].lower() == 'simple':

--- a/cme/cmedb.py
+++ b/cme/cmedb.py
@@ -55,6 +55,7 @@ class DatabaseNavigator(cmd.Cmd):
         line = line.split()
 
         # Need to use if/elif/else to keep compatibility with py3.8/3.9
+        # Reference DB Function cme/protocols/smb/database.py
         # Users
         if line[0].lower() == 'creds':
             if len(line) < 3:
@@ -80,12 +81,12 @@ class DatabaseNavigator(cmd.Cmd):
                     entry.append(cred[3]) # Password/Hash
                     entry.append(cred[4]) # Cred Type
                     
-                    
-                    if cred[5] == "":
-                        entry.append("Manual")
+                    print(cred[5])
+                    if cred[5] == None:
+                        entry.append("")
                     else:
                         entry.append(self.db.get_computers(cred[5])[0][2])
-                        formattedCreds.append(entry)
+                    formattedCreds.append(entry)
                 self.write_csv(filename,csv_header,formattedCreds)
             print('[+] creds exported')
 

--- a/cme/protocols/smb/database.py
+++ b/cme/protocols/smb/database.py
@@ -320,6 +320,9 @@ class database:
 
         elif hostID:
             cur.execute("SELECT * FROM admin_relations WHERE computerid=?", [hostID])
+        
+        else:
+            cur.execute("SELECT * FROM admin_relations")
 
         results = cur.fetchall()
         cur.close()


### PR DESCRIPTION
Sorry to make another PR so soon after the last one regarding roughly the same function.

In this PR, I've made a function `write_csv` that would simplify creating the CSV files. Using the CSV writer module to make sure other exports are also clean.

I've rewritten a bunch of the export features to follow the same calling convention of `export <shares/creds/hosts/local_admins> <simple/detailed> <filename>`.

Unfortunately, that does mean the export creds will now export both plaintext and hashes and will be up the user to filter out.

Finally, I also added `local_admins` to the export type to display what users have admin on what machines.

At the moment, I only have touched the SMB side of things, just wanted to get input before I continue onwards.

![image](https://user-images.githubusercontent.com/27817827/191774084-705b37e7-b4d7-4d62-9947-bf7e88a1eb76.png)

![image](https://user-images.githubusercontent.com/27817827/191775727-1a82b3c5-c442-4767-ac0e-0ce57caa2d78.png)
