### PR TITLE
Module to check for AlwaysInstallElevated

### DIFF
--- a/cme/modules/install_elevated.py
+++ b/cme/modules/install_elevated.py
@@ -1,0 +1,43 @@
+class CMEModule:
+
+    name = 'install_elevated'
+    description = "Checks for AlwaysInstallElevated"
+    supported_protocols = ['smb']
+    opsec_safe = True
+    multiple_hosts = True
+
+    def options(self, context, module_options):
+        '''
+        '''
+
+    def on_admin_login(self, context, connection):
+        remoteOps = RemoteOperations(connection.conn, False)
+        remoteOps.enableRegistry()
+
+        try:
+            ans_machine = rrp.hOpenLocalMachine(remoteOps._RemoteOperations__rrp)
+            regHandle = ans_machine['phKey']
+            ans_machine = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, 'SOFTWARE\\Policies\\Microsoft\\Windows\\Installer')
+            keyHandle = ans_machine['phkResult']
+            dataType, aie_machine_value = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, 'AlwaysInstallElevated')
+
+            rrp.hBaseRegCloseKey(remoteOps._RemoteOperations__rrp, keyHandle)
+
+
+            ans_user = rrp.hOpenCurrentUser(remoteOps._RemoteOperations__rrp)
+            regHandle = ans_user['phKey']
+            ans_user = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, 'SOFTWARE\\Policies\\Microsoft\\Windows\\Installer')
+            keyHandle = ans_user['phkResult']
+            dataType, aie_user_value = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, 'AlwaysInstallElevated')
+
+            if aie_user_value == 1 and aie_machine_value == 1:
+                context.log.highlight('AlwaysInstallElevated Status: 1 (Enabled)')
+            elif aie_user_value == 0 or aie_machine_value == 0:
+                context.log.highlight('AlwaysInstallElevated Status: 0 (Disabled)')
+
+            rrp.hBaseRegCloseKey(remoteOps._RemoteOperations__rrp, keyHandle)
+
+        except rrp.DCERPCSessionError:
+            context.log.highlight('AlwaysInstallElevated Status: 0 (Disabled)')
+
+        remoteOps.finish()


### PR DESCRIPTION
This module will check if the computer and the supplied user have AlwaysInstallElevated enabled.

Output will appear as follows:
**Enabled**
```
$ poetry run crackmapexec smb 192.168.1.178  -u User1 -p ********** -M install_elevated
SMB         192.168.1.178   445    DC01             [*] Windows 10.0 Build 17763 x64 (name:DC01) (domain:domain.local) (signing:True) (SMBv1:False)
SMB         192.168.1.178   445    DC01             [+] domain.local\User1:********  (Pwn3d!)
INSTALL... 192.168.1.178   445    DC01             AlwaysInstallElevated Status: 1 (Enabled)
```
**Enabled in HKLM only**
```
$ poetry run crackmapexec smb 192.168.1.178  -u User1 -p ********** -M install_elevated
SMB         192.168.1.178   445    DC01             [*] Windows 10.0 Build 17763 x64 (name:DC01) (domain:domain.local) (signing:True) (SMBv1:False)
SMB         192.168.1.178   445    DC01             [+] domain.local\User1:******** (Pwn3d!)
INSTALL... 192.168.1.178   445    DC01             AlwaysInstallElevated Status: 1 (Enabled: Computer Only)
```
**Disabled**
```
$ poetry run crackmapexec smb 192.168.1.178  -u User1 -p ********** -M install_elevated
SMB         192.168.1.178   445    DC01             [*] Windows 10.0 Build 17763 x64 (name:DC01) (domain:domain.local) (signing:True) (SMBv1:False)
SMB         192.168.1.178   445    DC01             [+] domain.local\User1:********  (Pwn3d!)
INSTALL... 192.168.1.178   445    DC01             AlwaysInstallElevated Status: 0 (Disabled)
```