### PR TITLE
Update teams_localdb.py to support multi users

### DIFF
--- a/cme/modules/teams_localdb.py
+++ b/cme/modules/teams_localdb.py
@@ -32,6 +32,8 @@ class CMEModule:
                     found = 1
                     self.parse_file(context, 'skypetoken_asm')
                     self.parse_file(context, 'SSOAUTHCOOKIE')
+                    f.seek(0)
+                    f.trunkate()
                 except Exception as e:
                     if 'STATUS_SHARING_VIOLATION' in str(e):
                         context.log.debug(str(e))


### PR DESCRIPTION
Multi user support added.
Otherwise the file at /tmp/teams_cookies2.txt gets mangled up and you don't get back any results as sqlite3 can access it but won't find any content.
This is when the module finds more than one user folder on the target system.