### PR TITLE
Fix #663 - Preventing non admin with access to share folder to READ and WRITE.

### DIFF
--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -1072,7 +1072,7 @@ class smb(connection):
         with open(self.args.put_file[0], 'rb') as file:
             try:
                 self.conn.putFile(self.args.share, self.args.put_file[1], file.read)
-                self.logger.success('Created file {} on \\\\{}{}'.format(self.args.put_file[0], self.args.share, self.args.put_file[1]))
+                self.logger.success('Created file {} on \\\\{}\\{}'.format(self.args.put_file[0], self.args.share, self.args.put_file[1]))
             except Exception as e:
                 self.logger.error('Error writing file to share {}: {}'.format(self.args.share, e))
 

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -1067,7 +1067,6 @@ class smb(connection):
 
         return entries
 
-    @requires_admin
     def put_file(self):
         self.logger.info('Copy {} to {}'.format(self.args.put_file[0], self.args.put_file[1]))
         with open(self.args.put_file[0], 'rb') as file:
@@ -1077,7 +1076,6 @@ class smb(connection):
             except Exception as e:
                 self.logger.error('Error writing file to share {}: {}'.format(self.args.share, e))
 
-    @requires_admin
     def get_file(self):
         self.logger.info('Copy {} to {}'.format(self.args.get_file[0], self.args.get_file[1]))
         with open(self.args.get_file[1], 'wb+') as file:


### PR DESCRIPTION
Remove the `@requires_admin` flag in methods `get_file` and `put_file`, and added a `\\` to the logger, so it displays correctly the file path.