### PR TITLE
Fix #668 - Remove @requires_admin flag for WMI queries

### DIFF
--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -931,7 +931,6 @@ class smb(connection):
     def pass_pol(self):
         return PassPolDump(self).dump()
 
-    @requires_admin
     def wmi(self, wmi_query=None, namespace=None):
         records = []
         if not namespace:


### PR DESCRIPTION
Although not typical, a non-administrator user can be assigned WMI privileges.

By removing `@requires_admin`, we allow non-administrators with special privileges to query WMI. If we do not have the privilege to make queries to WMI, we will receive an access denied error, which makes it more evident what is happening.