### PR TITLE
Fix #676 - bh_owned module output always returning false

### DIFF
--- a/cme/modules/bh_owned.py
+++ b/cme/modules/bh_owned.py
@@ -74,7 +74,9 @@ class CMEModule:
             with session.begin_transaction() as tx:
                 result = tx.run(
                     "MATCH (c:Computer {{name:\"{}\"}}) SET c.owned=True RETURN c.name AS name".format(host_fqdn))
-        if len(result.value()) > 0:
+                record = result.single()
+                value = record.value()
+        if len(value) > 0:
             context.log.success("Node {} successfully set as owned in BloodHound".format(host_fqdn))
         else:
             context.log.error(


### PR DESCRIPTION
Based on Neo4j documentation https://neo4j.com/docs/api/python-driver/current/api.html#neo4j.Result I added some modification to the result variable.

The way it was code, `result.value()` always return 0.