### PR TITLE
Specific port for each MSSQL target

### DIFF
--- a/cme/protocols/mssql.py
+++ b/cme/protocols/mssql.py
@@ -26,6 +26,12 @@ class mssql(connection):
         self.os_arch = None
         self.nthash = ''
 
+        if ":" in host:
+            self.specific_port = host.split(":")[1]
+            host = host.split(":")[0]
+        else:
+            self.specific_port = None
+
         connection.__init__(self, args, db, host)
 
     @staticmethod
@@ -69,10 +75,11 @@ class mssql(connection):
                 self.call_cmd_args()
 
     def proto_logger(self):
+        port = self.specific_port if self.specific_port else self.args.port
         self.logger = CMEAdapter(extra={
                                         'protocol': 'MSSQL',
                                         'host': self.host,
-                                        'port': self.args.port,
+                                        'port': port,
                                         'hostname': 'None'
                                         })
 
@@ -135,7 +142,8 @@ class mssql(connection):
 
     def create_conn_obj(self):
         try:
-            self.conn = tds.MSSQL(self.host, self.args.port, rowsPrinter=self.logger)
+            port = self.specific_port if self.specific_port else self.args.port
+            self.conn = tds.MSSQL(self.host, port, rowsPrinter=self.logger)
             self.conn.connect()
         except socket.error:
             return False


### PR DESCRIPTION
Hi !

This PR adds to MSSQL the possibility to specify a port for each target, instead of using the same port for all taken from the `--port` argument.

This is especially useful when extracting MSSQL instances from the domain's SPNs, which often use random, non-consistent ports. After this PR, CME can be used to quickly¹ check which MSSQL instances are up and responding, and which can be for instance accessed by a low-privileged user.

For MSSQL, targets can now be specified in the form `<target>:<port>`. If `<port>` is not supplied, CME will fallback on the port provided by the `--port` argument, the current behaviour.

Cheers!

¹: One issue subsists: CME relies on the impacket implementation of MSSQL, which does not allow specifying a SYN timeout. As such, CME will wait for a long time for a SYN/ACK before timing out, which can happen if the port is firewalled off or if the host does not exist anymore. Until the impacket project is active again to submit a PR, one can use this small patch on their local impacket library to set the MSSQL connect timeout to 2 seconds (for instance) to fasten CME:

```diff
diff --git a/impacket/tds.py b/impacket/tds.py
index b1b21250..90fdfe94 100644
--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -532,6 +532,7 @@ class MSSQL:
         sock = socket.socket(af, socktype, proto)
         
         try:
+            sock.settimeout(2)
             sock.connect(sa)
         except Exception:
             #import traceback
```


