### PR TITLE
Fix - Blank username when using Kerberos Auth (smb / mssql)

### DIFF
--- a/cme/protocols/mssql.py
+++ b/cme/protocols/mssql.py
@@ -12,6 +12,7 @@ from cme.helpers.bloodhound import add_user_bh
 from cme.helpers.powershell import create_ps_command
 from impacket import tds
 import configparser
+from impacket.krb5.ccache import CCache
 from impacket.smbconnection import SMBConnection, SessionError
 from impacket.tds import SQLErrorException, TDS_LOGINACK_TOKEN, TDS_ERROR_TOKEN, TDS_ENVCHANGE_TOKEN, TDS_INFO_TOKEN, \
     TDS_ENVCHANGE_VARCHAR, TDS_ENVCHANGE_DATABASE, TDS_ENVCHANGE_LANGUAGE, TDS_ENVCHANGE_CHARSET, TDS_ENVCHANGE_PACKETSIZE
@@ -189,7 +190,13 @@ class mssql(connection):
                 return False
 
             self.password = password
-            self.username = username
+            if username == '' and useCache:
+                ccache = CCache.loadFile(os.getenv('KRB5CCNAME'))
+                principal = ccache.principal.toPrincipal()
+                self.username = principal.components[0]
+                username = principal.components[0]
+            else:
+                self.username = username
             self.domain = domain
             self.check_if_admin()
 

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -357,7 +357,10 @@ class smb(connection):
         try:
             if not self.args.laps:
                 self.password = password
-                self.username = username
+                if username == '':
+                    self.username = self.conn.getCredentials()[0]
+                else:
+                    self.username = username
             #This checks to see if we didn't provide the LM Hash
             if ntlm_hash.find(':') != -1:
                 lmhash, nthash = ntlm_hash.split(':')

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -357,10 +357,7 @@ class smb(connection):
         try:
             if not self.args.laps:
                 self.password = password
-                if username == '':
-                    self.username = self.conn.getCredentials()[0]
-                else:
-                    self.username = username
+                self.username = username
             #This checks to see if we didn't provide the LM Hash
             if ntlm_hash.find(':') != -1:
                 lmhash, nthash = ntlm_hash.split(':')
@@ -372,6 +369,11 @@ class smb(connection):
             if nthash: self.nthash = nthash
             self.conn.kerberosLogin(username, password, domain, lmhash, nthash, aesKey, kdcHost, useCache=useCache)
             self.check_if_admin()
+            
+            if username == '':
+                self.username = self.conn.getCredentials()[0]
+            else:
+                self.username = username
 
             out = u'{}\\{}{} {}'.format(self.domain,
                                     self.username,


### PR DESCRIPTION
This change allows the program to return the name of the user being authenticated when using Kerberos when using smb or mssql protocol.