### PR TITLE
Fix cmedb displayed credentials for mssql

### DIFF
--- a/cme/protocols/mssql/db_navigator.py
+++ b/cme/protocols/mssql/db_navigator.py
@@ -14,10 +14,10 @@ class navigator(DatabaseNavigator):
         for cred in creds:
 
             credID = cred[0]
-            domain = cred[1]
-            username = cred[2]
-            password = cred[3]
-            credtype = cred[4]
+            credtype = cred[1]
+            domain = cred[2]
+            username = cred[3]
+            password = cred[4]
             # pillaged_from = cred[5]
 
             links = self.db.get_admin_relations(userID=credID)


### PR DESCRIPTION
The columns were not in the correct order, which caused them to be displayed incorrectly. This change properly orders the way CMEDB displays credentials in the mssql protocol.

Before: 
```
cmedb (default)(mssql) > creds

+Credentials---------+----------------------------------+-----------+---------------+---------------+
| CredID | Admin On  | CredType                         | Domain    | UserName      | Password      |
+--------+-----------+----------------------------------+-----------+---------------+---------------+
| 1      | 0 Host(s) | Database2                        | plaintext | DC01          | nicole        |
```

After:

```
cmedb (default)(mssql) > creds                                                                                                                                                                
                                                                                                                                                                                              
+Credentials---------+-----------+---------------+---------------+----------------------------------+                                                                                         
| CredID | Admin On  | CredType  | Domain        | UserName      | Password                         |                                                                                         
+--------+-----------+-----------+---------------+---------------+----------------------------------+                                                                                         
| 1      | 0 Host(s) | plaintext | DC01          | nicole        | Database2                        |
```