### PR TITLE
Modify remove_credentials to allow "creds remove"

### DIFF
--- a/cme/protocols/smb/database.py
+++ b/cme/protocols/smb/database.py
@@ -271,16 +271,16 @@ class database:
         logging.debug('add_group(domain={}, name={}) => {}'.format(domain, name, cur.lastrowid))
 
         return cur.lastrowid
-    '''
+    
     def remove_credentials(self, credIDs):
         """
         Removes a credential ID from the database
         """
         for credID in credIDs:
             cur = self.conn.cursor()
-            cur.execute("DELETE FROM credentials WHERE id=?", [credID])
+            cur.execute("DELETE FROM users WHERE id=?", [credID])
             cur.close()
-    '''
+            
     def add_admin_user(self, credtype, domain, username, password, host, userid=None):
 
         domain = domain.split('.')[0].upper()


### PR DESCRIPTION
`creds remove CredID` was not working because the method was commented on, I removed the comments and changed the table name from credentials to users.

```
| 45     | 0 Host(s) | plaintext | TEST            | usertest                 | passtest                                                          |
+--------+-----------+-----------+-----------------+--------------------------+-------------------------------------------------------------------+

cmedb (default)(smb) > creds remove 45
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/plaintext/htb/academy-testing/crackmapexec/pr/CrackMapExec/cme/cmedb.py", line 400, in main
    cmedbnav = CMEDBMenu(config_path)
  File "/home/plaintext/htb/academy-testing/crackmapexec/pr/CrackMapExec/cme/cmedb.py", line 300, in __init__
    self.do_proto(self.db)
  File "/home/plaintext/htb/academy-testing/crackmapexec/pr/CrackMapExec/cme/cmedb.py", line 326, in do_proto
    proto_menu.cmdloop()
  File "/usr/lib/python3.9/cmd.py", line 138, in cmdloop
    stop = self.onecmd(line)
  File "/usr/lib/python3.9/cmd.py", line 217, in onecmd
    return func(arg)
  File "/home/plaintext/htb/academy-testing/crackmapexec/pr/CrackMapExec/cme/protocols/smb/db_navigator.py", line 310, in do_creds
    self.db.remove_credentials(args)
AttributeError: 'database' object has no attribute 'remove_credentials'
```

After 

```
cmedb (default)(smb) > creds remove 45
cmedb (default)(smb) > creds 45

+Credentials--------+----------+--------+----------+----------+
| CredID | Admin On | CredType | Domain | UserName | Password |
+--------+----------+----------+--------+----------+----------+

```