### PR TITLE
remove duplicate license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 homepage = "https://github.com/Porchetta-Industries/CrackMapExec"
 repository = "https://github.com/Porchetta-Industries/CrackMapExec"
 exclude = []
-include = ["LICENSE", "cme/data/*", "cme/modules/*"]
+include = ["cme/data/*", "cme/modules/*"]
 license = "BSD-2-Clause"
 classifiers = [
     'Environment :: Console',


### PR DESCRIPTION
The license file is included two times and one is at the wrong place.

If we take a look at the wheel dist, we can see there is `LICENSE` at the root and also `crackmapexec-5.4.0.dist-info/LICENSE`:

```
$ 7z l dist/crackmapexec-5.4.0-py3-none-any.whl | grep -i license
1980-01-01 00:00:00 .....         1305          693  LICENSE
1980-01-01 00:00:00 .....         1305          693  crackmapexec-5.4.0.dist-info/LICENSE
```

But this is an issue, because when you install it on your system, it deploys one of the license file on the root path of the python site package directory:

```
$ tar tvf cme.tar.zst | grep -i license
-rwxr-xr-x root/root      1305 2022-11-23 15:05 usr/lib/python3.10/site-packages/LICENSE
-rwxr-xr-x root/root      1305 2022-11-23 15:05 usr/lib/python3.10/site-packages/crackmapexec-5.4.0.dist-info/LICENSE
```

So by removing the LICENSE from include it will remove `usr/lib/python3.10/site-packages/LICENSE` but keep `usr/lib/python3.10/site-packages/crackmapexec-5.4.0.dist-info/LICENSE`.

Other packages like https://github.com/nikitastupin/clairvoyance/pull/55 have the same issue which conflicts and prevent installing new tools with the same issue.

```
error: failed to commit transaction (conflicting files)
clairvoyance: /usr/lib/python3.10/site-packages/LICENSE exists in filesystem (owned by crackmapexec)
```