### PR TITLE
Fixed bh_owned error on non-existing  values

### DIFF
--- a/cme/modules/bh_owned.py
+++ b/cme/modules/bh_owned.py
@@ -75,7 +75,10 @@ class CMEModule:
                 result = tx.run(
                     "MATCH (c:Computer {{name:\"{}\"}}) SET c.owned=True RETURN c.name AS name".format(host_fqdn))
                 record = result.single()
-                value = record.value()
+                try:
+                    value = record.value()
+                except AttributeError:
+                    value = []
         if len(value) > 0:
             context.log.success("Node {} successfully set as owned in BloodHound".format(host_fqdn))
         else:


### PR DESCRIPTION
If a computer on the network has been compromised but is not listed in the Neo4j database. CME won't crash any more.
**Before**
![2022-11-25_15-58](https://user-images.githubusercontent.com/19536819/203981498-b413fd54-35fe-4e3f-ba8f-38532d340f58.png)

**After**
![2022-11-25_16-55](https://user-images.githubusercontent.com/19536819/203981619-c1872709-6687-490b-a463-d96605dc014e.png)

![2022-11-25_16-03](https://user-images.githubusercontent.com/19536819/203981665-33687631-13bb-4e4f-8f3f-50422c88ad8b.png)
