### PR TITLE
[Feat] - add flag for display only valid authentication

### DIFF
--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -150,6 +150,7 @@ class smb(connection):
         dgroup = smb_parser.add_mutually_exclusive_group()
         dgroup.add_argument("-d", metavar="DOMAIN", dest='domain', type=str, help="domain to authenticate to")
         dgroup.add_argument("--local-auth", action='store_true', help='authenticate locally to each target')
+        smb_parser.add_argument("--only-success", action='store_true', help="displays only machines where authentication is valid")
         smb_parser.add_argument("--port", type=int, choices={445, 139}, default=445, help="SMB port (default: 445)")
         smb_parser.add_argument("--share", metavar="SHARE", default="C$", help="specify a share (default: C$)")
         smb_parser.add_argument("--smb-server-port", default="445", help="specify a server port for SMB", type=int)
@@ -462,7 +463,10 @@ class smb(connection):
 
         except (SessionError) as e:
             error, desc = e.getErrorString()
-            self.logger.error(u'{}\\{}:{} {} {}'.format(domain,
+            if self.args.only_success == True:
+                pass
+            else:
+                self.logger.error(u'{}\\{}:{} {} {}'.format(domain,
                                                         self.username,
                                                         self.password if not self.config.get('CME', 'audit_mode') else self.config.get('CME', 'audit_mode')*8,
                                                         error,


### PR DESCRIPTION
Hello,
This is just an idea, but I think I'm not the only one with very large perimeters and miles of logs, so I propose a flag to display only valid authentications

![image](https://user-images.githubusercontent.com/15458329/204062459-dcdd217e-cc59-48ea-b482-9a3142d0004b.png)
