### PR TITLE
Add --success-only and --no-error option to cme in order to reduce log output and more

### DIFF
--- a/cme/cli.py
+++ b/cme/cli.py
@@ -41,6 +41,7 @@ def gen_cli_args():
     parser.add_argument("--jitter", metavar='INTERVAL', type=str, help='sets a random delay between each connection (default: None)')
     parser.add_argument("--darrell", action='store_true', help='give Darrell a hand')
     parser.add_argument("--verbose", action='store_true', help="enable verbose output")
+    parser.add_argument("--success", action='store_true', help="surpress all output except \"success\" and \"highlight\" logging output")
 
     subparsers = parser.add_subparsers(title='protocols', dest='protocol', description='available protocols')
 

--- a/cme/cli.py
+++ b/cme/cli.py
@@ -43,6 +43,7 @@ def gen_cli_args():
     parser.add_argument("--verbose", action='store_true', help="enable verbose output")
     parser.add_argument("--no-error", action='store_true', help="surpress error and warning log output")
     parser.add_argument("--success-only", action='store_true', help="surpress error, warning and info log output")
+    parser.add_argument("--output-file", type=str, help="append console output to a file (default: None)")
 
     subparsers = parser.add_subparsers(title='protocols', dest='protocol', description='available protocols')
 

--- a/cme/cli.py
+++ b/cme/cli.py
@@ -41,7 +41,8 @@ def gen_cli_args():
     parser.add_argument("--jitter", metavar='INTERVAL', type=str, help='sets a random delay between each connection (default: None)')
     parser.add_argument("--darrell", action='store_true', help='give Darrell a hand')
     parser.add_argument("--verbose", action='store_true', help="enable verbose output")
-    parser.add_argument("--success", action='store_true', help="surpress all output except \"success\" and \"highlight\" logging output")
+    parser.add_argument("--no-error", action='store_true', help="surpress error and warning log output")
+    parser.add_argument("--success-only", action='store_true', help="surpress error, warning and info log output")
 
     subparsers = parser.add_subparsers(title='protocols', dest='protocol', description='available protocols')
 

--- a/cme/cli.py
+++ b/cme/cli.py
@@ -54,7 +54,6 @@ def gen_cli_args():
     std_parser.add_argument("-p", metavar="PASSWORD", dest='password', nargs='+', default=[], help="password(s) or file(s) containing passwords")
     std_parser.add_argument("-k", "--kerberos", action='store_true', help="Use Kerberos authentication")
     std_parser.add_argument("--use-kcache", action='store_true', help="Use Kerberos authentication from ccache file (KRB5CCNAME)")
-    std_parser.add_argument("--export", metavar="EXPORT", nargs='+', help="Export result into a file, probably buggy")
     std_parser.add_argument("--aesKey",  metavar="AESKEY", nargs='+', help="AES key to use for Kerberos Authentication (128 or 256 bits)")
     std_parser.add_argument("--kdcHost", metavar="KDCHOST", help="FQDN of the domain controller. If omitted it will use the domain part (FQDN) specified in the target parameter")
 

--- a/cme/connection.py
+++ b/cme/connection.py
@@ -50,7 +50,6 @@ class connection(object):
         self.kerberos = True if self.args.kerberos or self.args.use_kcache else False
         self.aesKey = None if not self.args.aesKey else self.args.aesKey
         self.kdcHost = None if not self.args.kdcHost else self.args.kdcHost
-        self.export = None if not self.args.export else self.args.export
         self.failed_logins = 0
         self.local_ip = None
 
@@ -113,8 +112,6 @@ class connection(object):
                 if v is not False and v is not None:
                     logging.debug('Calling {}()'.format(k))
                     r = getattr(self, k)()
-                    if self.export:
-                        write_log(str(r), self.export[0])
 
     def call_modules(self):
         module_logger = CMEAdapter(extra={

--- a/cme/crackmapexec.py
+++ b/cme/crackmapexec.py
@@ -78,6 +78,8 @@ async def run_protocol(loop, protocol_obj, args, db, target, jitter):
         thread.cancel()
     except sqlite3.OperationalError as e:
         logging.debug("Sqlite error - sqlite3.operationalError - {}".format(str(e)))
+    except Exception as e:
+        logger.critical("Unhandled Exception while processing target {}".format(target), exc_info=True)
 
 async def start_threadpool(protocol_obj, args, db, targets, jitter):
     pool = ThreadPoolExecutor(max_workers=args.threads + 1)

--- a/cme/crackmapexec.py
+++ b/cme/crackmapexec.py
@@ -137,8 +137,10 @@ def main():
 
     if args.verbose:
         setup_debug_logger()
+    elif args.success:
+        setup_success_logger()
 
-    logging.debug('Passed args:\n' + pformat(vars(args)))
+    logger.debug('Passed args:\n' + pformat(vars(args)))
 
     if args.jitter:
         if '-' in args.jitter:

--- a/cme/crackmapexec.py
+++ b/cme/crackmapexec.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from cme.logger import setup_logger, setup_debug_logger, setup_info_logger, setup_success_logger, CMEAdapter
+from cme.logger import *
 from cme.helpers.logger import highlight
 from cme.helpers.misc import identify_target_file
 from cme.parsers.ip import parse_targets
@@ -135,12 +135,15 @@ def main():
     server_port_dict = {'http': 80, 'https': 443, 'smb': 445}
     current_workspace = config.get('CME', 'workspace')
 
+    # Logger setup
     if args.verbose:
         setup_debug_logger()
     elif args.no_error:
         setup_info_logger()
     elif args.success_only:
         setup_success_logger()
+    if args.output_file:
+        logger_set_output_file(args.output_file)
 
     logger.debug('Passed args:\n' + pformat(vars(args)))
 

--- a/cme/crackmapexec.py
+++ b/cme/crackmapexec.py
@@ -16,7 +16,6 @@ from cme.context import Context
 from concurrent.futures import ThreadPoolExecutor
 from pprint import pformat
 from decimal import Decimal
-import time
 import asyncio
 import aioconsole
 import functools
@@ -147,7 +146,7 @@ def main():
     if args.output_file:
         logger_set_output_file(args.output_file)
 
-    logger.debug('Passed args:\n' + pformat(vars(args)))
+    logging.debug('Passed args:\n' + pformat(vars(args)))
 
     if args.jitter:
         if '-' in args.jitter:

--- a/cme/crackmapexec.py
+++ b/cme/crackmapexec.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from cme.logger import setup_logger, setup_debug_logger, CMEAdapter
+from cme.logger import setup_logger, setup_debug_logger, setup_success_logger, CMEAdapter
 from cme.helpers.logger import highlight
 from cme.helpers.misc import identify_target_file
 from cme.parsers.ip import parse_targets

--- a/cme/crackmapexec.py
+++ b/cme/crackmapexec.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from cme.logger import setup_logger, setup_debug_logger, setup_success_logger, CMEAdapter
+from cme.logger import setup_logger, setup_debug_logger, setup_info_logger, setup_success_logger, CMEAdapter
 from cme.helpers.logger import highlight
 from cme.helpers.misc import identify_target_file
 from cme.parsers.ip import parse_targets
@@ -137,7 +137,9 @@ def main():
 
     if args.verbose:
         setup_debug_logger()
-    elif args.success:
+    elif args.no_error:
+        setup_info_logger()
+    elif args.success_only:
         setup_success_logger()
 
     logger.debug('Passed args:\n' + pformat(vars(args)))

--- a/cme/helpers/logger.py
+++ b/cme/helpers/logger.py
@@ -3,6 +3,8 @@
 
 import os
 import random
+import logging
+import re
 from termcolor import colored
 
 def write_log(data, log_name):
@@ -15,3 +17,9 @@ def highlight(text, color='yellow'):
         return u'{}'.format(colored(text, 'yellow', attrs=['bold']))
     elif color == 'red':
         return u'{}'.format(colored(text, 'red', attrs=['bold']))
+
+class AnsiRemoveFormatter(logging.Formatter):
+    def format(self, record):
+        ansi_escape = re.compile(r'\x1b\[[0-9;]*m')
+        record.msg = ansi_escape.sub('', record.msg)
+        return super(AnsiRemoveFormatter, self).format(record)

--- a/cme/logger.py
+++ b/cme/logger.py
@@ -92,6 +92,11 @@ class CMEAdapter(logging.LoggerAdapter):
         self.logger._log(27, msg, args, **kwargs)
     setattr(logging.getLoggerClass(), 'highlight', highlight)
 
+    # Use this for exception handling
+    def critical(self, msg, *args, **kwargs):
+        msg, kwargs = self.process(u'{} {}'.format(colored("[!]", 'red', attrs=['bold']), msg), kwargs)
+        self.logger.critical(msg, *args, **kwargs)
+
     # For Impacket's TDS library
     def logMessage(self, message):
         CMEAdapter.message += message.strip().replace('NULL', '') + '\n'

--- a/cme/logger.py
+++ b/cme/logger.py
@@ -9,6 +9,7 @@ from cme.helpers.logger import AnsiRemoveFormatter
 from termcolor import colored
 from datetime import datetime
 
+
 class CMEAdapter(logging.LoggerAdapter):
 
     # For Impacket's TDS library
@@ -32,25 +33,25 @@ class CMEAdapter(logging.LoggerAdapter):
             if len(self.extra['module']) > 8:
                 self.extra['module'] = self.extra['module'][:8] + '...'
 
-        #If the logger is being called when hooking the 'options' module function
+        # If the logger is being called when hooking the 'options' module function
         if len(self.extra) == 1 and ('module' in self.extra.keys()):
             return u'{:<64} {}'.format(colored(self.extra['module'], 'cyan', attrs=['bold']), msg), kwargs
 
-        #If the logger is being called from CMEServer
+        # If the logger is being called from CMEServer
         if len(self.extra) == 2 and ('module' in self.extra.keys()) and ('host' in self.extra.keys()):
             return u'{:<24} {:<39} {}'.format(colored(self.extra['module'], 'cyan', attrs=['bold']), self.extra['host'], msg), kwargs
 
-        #If the logger is being called from a protocol
+        # If the logger is being called from a protocol
         if 'module' in self.extra.keys():
             module_name = colored(self.extra['module'], 'cyan', attrs=['bold'])
         else:
             module_name = colored(self.extra['protocol'], 'blue', attrs=['bold'])
 
         return u'{:<24} {:<15} {:<6} {:<16} {}'.format(module_name,
-                                                    self.extra['host'],
-                                                    self.extra['port'],
-                                                    self.extra['hostname'] if self.extra['hostname'] else 'NONE',
-                                                    msg), kwargs
+                                                       self.extra['host'],
+                                                       self.extra['port'],
+                                                       self.extra['hostname'] if self.extra['hostname'] else 'NONE',
+                                                       msg), kwargs
 
     def info(self, msg, *args, **kwargs):
         try:
@@ -92,13 +93,14 @@ class CMEAdapter(logging.LoggerAdapter):
     setattr(logging.getLoggerClass(), 'highlight', highlight)
 
     # For Impacket's TDS library
-    def logMessage(self,message):
+    def logMessage(self, message):
         CMEAdapter.message += message.strip().replace('NULL', '') + '\n'
 
     def getMessage(self):
         out = CMEAdapter.message
         CMEAdapter.message = ''
         return out
+
 
 def logger_set_output_file(output_file):
     formatter = logging.Formatter("%(asctime)s %(message)s", "%Y-%m-%d %H:%M:%S")
@@ -112,6 +114,7 @@ def logger_set_output_file(output_file):
     cme_logger.addHandler(fileHandler)
     root_logger = logging.getLogger()
     root_logger.addHandler(fileHandler)
+
 
 def setup_debug_logger():
     debug_output_string = "{} %(message)s".format(colored('DEBUG', 'magenta', attrs=['bold']))
@@ -131,11 +134,13 @@ class ExactLogLevelFilter(object):
 
     Example: logging.getLogger('mylogger').addFilter(ExactLogLevelFilter(logging.INFO))
     """
+
     def __init__(self, level):
         self.__level = level
 
     def filter(self, logRecord):
         return logRecord.levelno == self.__level
+
 
 class RangeLogLevelFilter(object):
     """
@@ -143,6 +148,7 @@ class RangeLogLevelFilter(object):
 
     Example: logging.getLogger('mylogger').addFilter(RangeLogLevelFilter(logging.INFO, logging.WARNING))
     """
+
     def __init__(self, level_min, level_max):
         self.__level_min = level_min
         self.__level_max = level_max
@@ -150,9 +156,11 @@ class RangeLogLevelFilter(object):
     def filter(self, logRecord):
         return (self.__level_min <= logRecord.levelno <= self.__level_max)
 
+
 def setup_info_logger(logger_name='CME'):
     cme_logger = logging.getLogger(logger_name)
     cme_logger.addFilter(RangeLogLevelFilter(logging.INFO, logging.HIGHLIGHT))
+
 
 def setup_success_logger(logger_name='CME'):
     cme_logger = logging.getLogger(logger_name)

--- a/cme/logger.py
+++ b/cme/logger.py
@@ -154,6 +154,10 @@ class RangeLogLevelFilter(object):
     def filter(self, logRecord):
         return (self.__level_min <= logRecord.levelno <= self.__level_max)
 
+def setup_info_logger(logger_name='CME'):
+    cme_logger = logging.getLogger(logger_name)
+    cme_logger.addFilter(RangeLogLevelFilter(logging.INFO, logging.HIGHLIGHT))
+
 def setup_success_logger(logger_name='CME'):
     cme_logger = logging.getLogger(logger_name)
     cme_logger.addFilter(RangeLogLevelFilter(logging.SUCCESS, logging.HIGHLIGHT))

--- a/cme/logger.py
+++ b/cme/logger.py
@@ -127,10 +127,39 @@ def setup_debug_logger():
     root_logger.addHandler(streamHandler)
     #root_logger.addHandler(fileHandler)
     root_logger.setLevel(logging.DEBUG)
-    return root_logger
+
+# Filter Example for future use cases
+class ExactLogLevelFilter(object):
+    """
+    Filter for one specific log level
+
+    Example: logging.getLogger('mylogger').addFilter(ExactLogLevelFilter(logging.INFO))
+    """
+    def __init__(self, level):
+        self.__level = level
+
+    def filter(self, logRecord):
+        return logRecord.levelno == self.__level
+
+class RangeLogLevelFilter(object):
+    """
+    Allow log records which have a level between \"level_min\" and \"level_max\"
+
+    Example: logging.getLogger('mylogger').addFilter(RangeLogLevelFilter(logging.INFO, logging.WARNING))
+    """
+    def __init__(self, level_min, level_max):
+        self.__level_min = level_min
+        self.__level_max = level_max
+
+    def filter(self, logRecord):
+        return (self.__level_min <= logRecord.levelno <= self.__level_max)
+
+def setup_success_logger(logger_name='CME'):
+    cme_logger = logging.getLogger(logger_name)
+    cme_logger.addFilter(RangeLogLevelFilter(logging.SUCCESS, logging.HIGHLIGHT))
+
 
 def setup_logger(level=logging.INFO, log_to_file=False, log_prefix=None, logger_name='CME'):
-
     formatter = logging.Formatter("%(message)s")
 
     if log_to_file:
@@ -152,5 +181,3 @@ def setup_logger(level=logging.INFO, log_to_file=False, log_prefix=None, logger_
         cme_logger.addHandler(fileHandler)
 
     cme_logger.setLevel(level)
-
-    return cme_logger

--- a/cme/logger.py
+++ b/cme/logger.py
@@ -34,6 +34,12 @@ class CMEAdapter(logging.LoggerAdapter):
         self.logger = logging.getLogger(logger_name)
         self.extra = extra
 
+        # Adding the costum loglevel 'SUCCESS' and 'HIGHLIGHT'
+        logging.addLevelName(23, 'SUCCESS')
+        logging.addLevelName(27, 'HIGHLIGHT')
+        logging.SUCCESS = 23
+        logging.HIGHLIGHT = 27
+
     def process(self, msg, kwargs):
         if self.extra is None:
             return u'{}'.format(msg), kwargs
@@ -87,7 +93,8 @@ class CMEAdapter(logging.LoggerAdapter):
             pass
 
         msg, kwargs = self.process(u'{} {}'.format(colored("[+]", 'green', attrs=['bold']), msg), kwargs)
-        self.logger.info(msg, *args, **kwargs)
+        self.logger._log(23, msg, args, **kwargs)
+    setattr(logging.getLoggerClass(), 'success', success)
 
     def highlight(self, msg, *args, **kwargs):
         try:
@@ -97,7 +104,8 @@ class CMEAdapter(logging.LoggerAdapter):
             pass
 
         msg, kwargs = self.process(u'{}'.format(colored(msg, 'yellow', attrs=['bold'])), kwargs)
-        self.logger.info(msg, *args, **kwargs)
+        self.logger._log(27, msg, args, **kwargs)
+    setattr(logging.getLoggerClass(), 'highlight', highlight)
 
     # For Impacket's TDS library
     def logMessage(self,message):

--- a/cme/logger.py
+++ b/cme/logger.py
@@ -105,31 +105,9 @@ class CMEAdapter(logging.LoggerAdapter):
         CMEAdapter.message = ''
         return out
 
-
-def logger_set_output_file(output_file):
-    formatter = AnsiRemoveFormatter("%(asctime)s %(message)s", "%Y-%m-%d %H:%M:%S")
-
-    fileHandler = logging.FileHandler(output_file)
-    fileHandler.setFormatter(formatter)
-
-    cme_logger = logging.getLogger('CME')
-    cme_logger.addHandler(fileHandler)
-    root_logger = logging.getLogger()
-    root_logger.addHandler(fileHandler)
-
-
-def setup_debug_logger():
-    debug_output_string = "{} %(message)s".format(colored('DEBUG', 'magenta', attrs=['bold']))
-    formatter = logging.Formatter(debug_output_string)
-    streamHandler = logging.StreamHandler(sys.stdout)
-    streamHandler.setFormatter(formatter)
-
-    root_logger = logging.getLogger()
-    root_logger.handlers = []
-    root_logger.addHandler(streamHandler)
-    root_logger.setLevel(logging.DEBUG)
-
 # Filter Example for future use cases
+
+
 class ExactLogLevelFilter(object):
     """
     Filter for one specific log level
@@ -169,16 +147,32 @@ def setup_success_logger(logger_name='CME'):
     cme_logger.addFilter(RangeLogLevelFilter(logging.SUCCESS, logging.HIGHLIGHT))
 
 
-def setup_logger(level=logging.INFO, log_to_file=False, log_prefix=None, logger_name='CME'):
+def logger_set_output_file(output_file):
+    formatter = AnsiRemoveFormatter("%(asctime)s %(message)s", "%Y-%m-%d %H:%M:%S")
+
+    fileHandler = logging.FileHandler(output_file)
+    fileHandler.setFormatter(formatter)
+
+    cme_logger = logging.getLogger('CME')
+    cme_logger.addHandler(fileHandler)
+    root_logger = logging.getLogger()
+    root_logger.addHandler(fileHandler)
+
+
+def setup_debug_logger():
+    debug_output_string = "{} %(message)s".format(colored('DEBUG', 'magenta', attrs=['bold']))
+    formatter = logging.Formatter(debug_output_string)
+    streamHandler = logging.StreamHandler(sys.stdout)
+    streamHandler.setFormatter(formatter)
+
+    root_logger = logging.getLogger()
+    root_logger.handlers = []
+    root_logger.addHandler(streamHandler)
+    root_logger.setLevel(logging.DEBUG)
+
+
+def setup_logger(level=logging.INFO, logger_name='CME'):
     formatter = logging.Formatter("%(message)s")
-
-    if log_to_file:
-        if not log_prefix:
-            log_prefix = 'log'
-
-        log_filename = '{}_{}.log'.format(log_prefix.replace('/', '_'), datetime.now().strftime('%Y-%m-%d'))
-        fileHandler = logging.FileHandler('./logs/{}'.format(log_filename))
-        fileHandler.setFormatter(formatter)
 
     streamHandler = logging.StreamHandler(sys.stdout)
     streamHandler.setFormatter(formatter)
@@ -186,8 +180,5 @@ def setup_logger(level=logging.INFO, log_to_file=False, log_prefix=None, logger_
     cme_logger = logging.getLogger(logger_name)
     cme_logger.propagate = False
     cme_logger.addHandler(streamHandler)
-
-    if log_to_file:
-        cme_logger.addHandler(fileHandler)
 
     cme_logger.setLevel(level)

--- a/cme/logger.py
+++ b/cme/logger.py
@@ -3,7 +3,6 @@
 
 import logging
 import sys
-import re
 from cme.helpers.misc import called_from_cmd_args
 from cme.helpers.logger import AnsiRemoveFormatter
 from termcolor import colored

--- a/cme/logger.py
+++ b/cme/logger.py
@@ -5,25 +5,9 @@ import logging
 import sys
 import re
 from cme.helpers.misc import called_from_cmd_args
+from cme.helpers.logger import AnsiRemoveFormatter
 from termcolor import colored
 from datetime import datetime
-
-#The following hooks the FileHandler.emit function to remove ansi chars before logging to a file
-#There must be a better way of doing this, but this way we might save some penguins!
-
-ansi_escape = re.compile(r'\x1b\[[0-9;]*m')
-
-def antiansi_emit(self, record):
-
-    if self.stream is None:
-        self.stream = self._open()
-
-    record.msg = ansi_escape.sub('', record.message)
-    logging.StreamHandler.emit(self, record)
-
-logging.FileHandler.emit = antiansi_emit
-
-####################################################################
 
 class CMEAdapter(logging.LoggerAdapter):
 
@@ -118,9 +102,11 @@ class CMEAdapter(logging.LoggerAdapter):
 
 def logger_set_output_file(output_file):
     formatter = logging.Formatter("%(asctime)s %(message)s", "%Y-%m-%d %H:%M:%S")
+    ansi_remove = AnsiRemoveFormatter("%(message)s)")
 
     fileHandler = logging.FileHandler(output_file)
     fileHandler.setFormatter(formatter)
+    fileHandler.setFormatter(ansi_remove)
 
     cme_logger = logging.getLogger('CME')
     cme_logger.addHandler(fileHandler)

--- a/cme/logger.py
+++ b/cme/logger.py
@@ -11,7 +11,7 @@ from datetime import datetime
 #The following hooks the FileHandler.emit function to remove ansi chars before logging to a file
 #There must be a better way of doing this, but this way we might save some penguins!
 
-ansi_escape = re.compile(r'\x1b[^m]*m')
+ansi_escape = re.compile(r'\x1b\[[0-9;]*m')
 
 def antiansi_emit(self, record):
 
@@ -116,6 +116,17 @@ class CMEAdapter(logging.LoggerAdapter):
         CMEAdapter.message = ''
         return out
 
+def logger_set_output_file(output_file):
+    formatter = logging.Formatter("%(asctime)s %(message)s", "%Y-%m-%d %H:%M:%S")
+
+    fileHandler = logging.FileHandler(output_file)
+    fileHandler.setFormatter(formatter)
+
+    cme_logger = logging.getLogger('CME')
+    cme_logger.addHandler(fileHandler)
+    root_logger = logging.getLogger()
+    root_logger.addHandler(fileHandler)
+
 def setup_debug_logger():
     debug_output_string = "{} %(message)s".format(colored('DEBUG', 'magenta', attrs=['bold']))
     formatter = logging.Formatter(debug_output_string)
@@ -125,7 +136,6 @@ def setup_debug_logger():
     root_logger = logging.getLogger()
     root_logger.handlers = []
     root_logger.addHandler(streamHandler)
-    #root_logger.addHandler(fileHandler)
     root_logger.setLevel(logging.DEBUG)
 
 # Filter Example for future use cases

--- a/cme/logger.py
+++ b/cme/logger.py
@@ -103,12 +103,10 @@ class CMEAdapter(logging.LoggerAdapter):
 
 
 def logger_set_output_file(output_file):
-    formatter = logging.Formatter("%(asctime)s %(message)s", "%Y-%m-%d %H:%M:%S")
-    ansi_remove = AnsiRemoveFormatter("%(message)s)")
+    formatter = AnsiRemoveFormatter("%(asctime)s %(message)s", "%Y-%m-%d %H:%M:%S")
 
     fileHandler = logging.FileHandler(output_file)
     fileHandler.setFormatter(formatter)
-    fileHandler.setFormatter(ansi_remove)
 
     cme_logger = logging.getLogger('CME')
     cme_logger.addHandler(fileHandler)

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ dsinternals==1.2.4; python_version >= "3.4"
 flask==2.2.2; python_version >= "3.7"
 future==0.18.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6"
 idna==3.4; python_version >= "3.7" and python_version < "4"
-impacket @ git+https://github.com/SecureAuthCorp/impacket.git@master
+impacket @ git+https://github.com/mpgn/impacket.git@master
 importlib-metadata==4.2.0; python_version < "3.8" and python_version >= "3.7"
 itsdangerous==2.1.2; python_version >= "3.7"
 jinja2==3.1.2; python_version >= "3.7"


### PR DESCRIPTION
## "success-only" option
Implemented an option `--success-only`, that suppresses every log message except loglevel `SUCCESS` and `HIGHLIGHT`, latter to still be able to dump credentials via `--lsa` and `--sam`.

This implementation is based on the idea from #691 and should reduce the amount of logs when working in large environments.

Example:
![image](https://user-images.githubusercontent.com/61382599/219514930-cc38c7b5-a297-44e4-b207-5b3f694a9dee.png)

## "no-error" option
Also added option `--no-error` to also let info log messages through the filter. Helpful if you want to scan large domains and just want to surpress failed logins.

Example:
![image](https://user-images.githubusercontent.com/61382599/219514965-0df81939-e2e7-4a29-bb4d-7c7fb4bae17b.png)

## Improve Exception handling
When exceptions occur there will be now a "critical" log message to improve visibility where the exception occurred.
This should drastically improve the visibility where exception occurre while scanning large target ranges.

Example:
![cme_exception_handling](https://user-images.githubusercontent.com/61382599/222921352-9392ce99-72f3-4eb2-864f-582f2e053102.png)

### Bug fixes:
- Stop the logger from printing duplicate logs when using `--verbose`