### PR TITLE
Fix ccache kerberos auth using rpc

### DIFF
--- a/cme/modules/dfscoerce.py
+++ b/cme/modules/dfscoerce.py
@@ -24,7 +24,7 @@ class CMEModule:
 
     def on_login(self, context, connection):
         trigger = TriggerAuth()
-        dce = trigger.connect(username=connection.username, password=connection.password, domain=connection.domain, lmhash=connection.lmhash, nthash=connection.nthash, target=connection.host)
+        dce = trigger.connect(username=connection.username, password=connection.password, domain=connection.domain, lmhash=connection.lmhash, nthash=connection.nthash, target=connection.host, doKerberos=connection.kerberos, dcHost=connection.kdcHost)
 
         if dce is not None: 
             logging.debug("Target is vulnerable to DFSCoerce")
@@ -78,13 +78,13 @@ class NetrDfsAddRootResponse(NDRCALL):
      )
 
 class TriggerAuth():
-    def connect(self, username, password, domain, lmhash, nthash, target):
+    def connect(self, username, password, domain, lmhash, nthash, target, doKerberos, dcHost):
         rpctransport = transport.DCERPCTransportFactory(r'ncacn_np:%s[\PIPE\netdfs]' % target)
         if hasattr(rpctransport, 'set_credentials'):
             rpctransport.set_credentials(username=username, password=password, domain=domain, lmhash=lmhash, nthash=nthash)
 
-        #if doKerberos:
-        #    rpctransport.set_kerberos(doKerberos, kdcHost=dcHost)
+        if doKerberos:
+            rpctransport.set_kerberos(doKerberos, kdcHost=dcHost)
         #if target:
         #    rpctransport.setRemoteHost(target)
         

--- a/cme/protocols/smb/passpol.py
+++ b/cme/protocols/smb/passpol.py
@@ -75,7 +75,7 @@ class PassPolDump:
 
     def __init__(self, connection):
         self.logger = connection.logger
-        self.addr = connection.host
+        self.addr = connection.host if not connection.kerberos else connection.hostname
         self.protocol = connection.args.port
         self.username = connection.username
         self.password = connection.password

--- a/cme/protocols/smb/passpol.py
+++ b/cme/protocols/smb/passpol.py
@@ -84,7 +84,7 @@ class PassPolDump:
         self.lmhash = ''
         self.nthash = ''
         self.aesKey = None
-        self.doKerberos = False
+        self.doKerberos = connection.kerberos
         self.protocols = PassPolDump.KNOWN_PROTOCOLS.keys()
         self.pass_pol = {}
 

--- a/cme/protocols/smb/samruser.py
+++ b/cme/protocols/smb/samruser.py
@@ -28,7 +28,7 @@ class UserSamrDump:
         self.lmhash = ''
         self.nthash = ''
         self.aesKey = None
-        self.doKerberos = False
+        self.doKerberos = connection.kerberos
         self.protocols = UserSamrDump.KNOWN_PROTOCOLS.keys()
         self.users = []
 

--- a/cme/protocols/smb/samruser.py
+++ b/cme/protocols/smb/samruser.py
@@ -19,7 +19,7 @@ class UserSamrDump:
 
     def __init__(self, connection):
         self.logger = connection.logger
-        self.addr = connection.host
+        self.addr = connection.host if not connection.kerberos else connection.hostname
         self.protocol = connection.args.port
         self.username = connection.username
         self.password = connection.password


### PR DESCRIPTION
Hello ! The kerberos authentication using a ccache file was returning a "logon" failure when using RPC/SMB with the users enumeration `--users`, Password policy `--pass-pol` and the modules shadowcoerce, petitpotam, dfscoerce. I've tested the fix using the NTLM password and kerberos using a ccache, and it's working for me.

Thanks!

Output before the fix:
```
export KRB5CCNAME=/opt/Temp/GOAD/sql_svc.ccache; crackmapexec smb meereen.essos.local -u sql_svc --kdcHost meereen.essos.local --use-kcache --users
SMB         meereen.essos.local 445    MEEREEN          [*] Windows Server 2016 Datacenter 14393 x64 (name:MEEREEN) (domain:essos.local) (signing:True) (SMBv1:True)
SMB         meereen.essos.local 445    MEEREEN          [+] essos.local\sql_svc from ccache 
SMB         meereen.essos.local 445    MEEREEN          [-] Error enumerating domain users using dc ip meereen.essos.local: NTLM needs domain\username and a password
SMB         meereen.essos.local 445    MEEREEN          [*] Trying with SAMRPC protocol

export KRB5CCNAME=/opt/Temp/GOAD/sql_svc.ccache; crackmapexec smb meereen.essos.local -u sql_svc --kdcHost meereen.essos.local --use-kcache --pass-pol
SMB         meereen.essos.local 445    MEEREEN          [*] Windows Server 2016 Datacenter 14393 x64 (name:MEEREEN) (domain:essos.local) (signing:True) (SMBv1:True)
SMB         meereen.essos.local 445    MEEREEN          [+] essos.local\sql_svc from ccache 

export KRB5CCNAME=/opt/Temp/GOAD/sql_svc.ccache; crackmapexec smb meereen.essos.local -u sql_svc --kdcHost meereen.essos.local --use-kcache -M shadowcoerce
SMB         meereen.essos.local 445    MEEREEN          [*] Windows Server 2016 Datacenter 14393 x64 (name:MEEREEN) (domain:essos.local) (signing:True) (SMBv1:True)
SMB         meereen.essos.local 445    MEEREEN          [+] essos.local\sql_svc from ccache 

export KRB5CCNAME=/opt/Temp/GOAD/sql_svc.ccache; crackmapexec smb meereen.essos.local -u sql_svc --kdcHost meereen.essos.local --use-kcache -M petitpotam
SMB         meereen.essos.local 445    MEEREEN          [*] Windows Server 2016 Datacenter 14393 x64 (name:MEEREEN) (domain:essos.local) (signing:True) (SMBv1:True)
SMB         meereen.essos.local 445    MEEREEN          [+] essos.local\sql_svc from ccache 

export KRB5CCNAME=/opt/Temp/GOAD/sql_svc.ccache; crackmapexec smb meereen.essos.local -u sql_svc --kdcHost meereen.essos.local --use-kcache -M dfscoerce
SMB         meereen.essos.local 445    MEEREEN          [*] Windows Server 2016 Datacenter 14393 x64 (name:MEEREEN) (domain:essos.local) (signing:True) (SMBv1:True)
SMB         meereen.essos.local 445    MEEREEN          [+] essos.local\sql_svc from ccache 
```

Verbose: [cme_output_verbose.txt](https://github.com/Porchetta-Industries/CrackMapExec/files/10685663/cme_output_verbose.txt)


Output after the fix:
```
export KRB5CCNAME=/opt/Temp/GOAD/sql_svc.ccache; poetry run crackmapexec smb meereen.essos.local -u sql_svc --kdcHost meereen.essos.local --use-kcache --users
SMB         meereen.essos.local 445    MEEREEN          [*] Windows Server 2016 Datacenter 14393 x64 (name:MEEREEN) (domain:essos.local) (signing:True) (SMBv1:True)
SMB         meereen.essos.local 445    MEEREEN          [+] essos.local\sql_svc from ccache 
SMB         meereen.essos.local 445    MEEREEN          [-] Error enumerating domain users using dc ip meereen.essos.local: SMB SessionError: STATUS_LOGON_FAILURE(The attempted logon is invalid. This is either due to a bad username or authentication information.)
SMB         meereen.essos.local 445    MEEREEN          [*] Trying with SAMRPC protocol
SMB         meereen.essos.local 445    MEEREEN          [+] Enumerated domain user(s)
SMB         meereen.essos.local 445    MEEREEN          essos.local\Administrator                  Built-in account for administering the computer/domain
SMB         meereen.essos.local 445    MEEREEN          essos.local\Guest                          Built-in account for guest access to the computer/domain
SMB         meereen.essos.local 445    MEEREEN          essos.local\krbtgt                         Key Distribution Center Service Account
SMB         meereen.essos.local 445    MEEREEN          essos.local\DefaultAccount                 A user account managed by the system.
SMB         meereen.essos.local 445    MEEREEN          essos.local\snaplabs                       
SMB         meereen.essos.local 445    MEEREEN          essos.local\daenerys.targaryen             Darnerys Targaryen
SMB         meereen.essos.local 445    MEEREEN          essos.local\viserys.targaryen              Viserys Targaryen
SMB         meereen.essos.local 445    MEEREEN          essos.local\khal.drogo                     Khal Drogo
SMB         meereen.essos.local 445    MEEREEN          essos.local\jorah.mormont                  Jorah Mormont
SMB         meereen.essos.local 445    MEEREEN          essos.local\sql_svc                        sql service

export KRB5CCNAME=/opt/Temp/GOAD/sql_svc.ccache; poetry run crackmapexec smb meereen.essos.local -u sql_svc --kdcHost meereen.essos.local --use-kcache --pass-pol
SMB         meereen.essos.local 445    MEEREEN          [*] Windows Server 2016 Datacenter 14393 x64 (name:MEEREEN) (domain:essos.local) (signing:True) (SMBv1:True)
SMB         meereen.essos.local 445    MEEREEN          [+] essos.local\sql_svc from ccache 
SMB         meereen.essos.local 445    MEEREEN          [+] Dumping password info for domain: ESSOS
SMB         meereen.essos.local 445    MEEREEN          Minimum password length: 5
SMB         meereen.essos.local 445    MEEREEN          Password history length: 24
SMB         meereen.essos.local 445    MEEREEN          Maximum password age: 311 days 2 minutes 
SMB         meereen.essos.local 445    MEEREEN          
SMB         meereen.essos.local 445    MEEREEN          Password Complexity Flags: 000000
SMB         meereen.essos.local 445    MEEREEN          	Domain Refuse Password Change: 0
SMB         meereen.essos.local 445    MEEREEN          	Domain Password Store Cleartext: 0
SMB         meereen.essos.local 445    MEEREEN          	Domain Password Lockout Admins: 0
SMB         meereen.essos.local 445    MEEREEN          	Domain Password No Clear Change: 0
SMB         meereen.essos.local 445    MEEREEN          	Domain Password No Anon Change: 0
SMB         meereen.essos.local 445    MEEREEN          	Domain Password Complex: 0
SMB         meereen.essos.local 445    MEEREEN          
SMB         meereen.essos.local 445    MEEREEN          Minimum password age: 1 day 4 minutes 
SMB         meereen.essos.local 445    MEEREEN          Reset Account Lockout Counter: 5 minutes 
SMB         meereen.essos.local 445    MEEREEN          Locked Account Duration: 5 minutes 
SMB         meereen.essos.local 445    MEEREEN          Account Lockout Threshold: 5
SMB         meereen.essos.local 445    MEEREEN          Forced Log off Time: Not Set

export KRB5CCNAME=/opt/Temp/GOAD/sql_svc.ccache; poetry run crackmapexec smb meereen.essos.local -u sql_svc --kdcHost meereen.essos.local --use-kcache -M shadowcoerce
SMB         meereen.essos.local 445    MEEREEN          [*] Windows Server 2016 Datacenter 14393 x64 (name:MEEREEN) (domain:essos.local) (signing:True) (SMBv1:True)
SMB         meereen.essos.local 445    MEEREEN          [+] essos.local\sql_svc from ccache 

export KRB5CCNAME=/opt/Temp/GOAD/sql_svc.ccache; poetry run crackmapexec smb meereen.essos.local -u sql_svc --kdcHost meereen.essos.local --use-kcache -M petitpotam
SMB         meereen.essos.local 445    MEEREEN          [*] Windows Server 2016 Datacenter 14393 x64 (name:MEEREEN) (domain:essos.local) (signing:True) (SMBv1:True)
SMB         meereen.essos.local 445    MEEREEN          [+] essos.local\sql_svc from ccache 
PETITPOT... meereen.essos.local 445    MEEREEN          VULNERABLE
PETITPOT... meereen.essos.local 445    MEEREEN          Next step: https://github.com/topotam/PetitPotam

export KRB5CCNAME=/opt/Temp/GOAD/sql_svc.ccache; poetry run crackmapexec smb meereen.essos.local -u sql_svc --kdcHost meereen.essos.local --use-kcache -M dfscoerce
SMB         meereen.essos.local 445    MEEREEN          [*] Windows Server 2016 Datacenter 14393 x64 (name:MEEREEN) (domain:essos.local) (signing:True) (SMBv1:True)
SMB         meereen.essos.local 445    MEEREEN          [+] essos.local\sql_svc from ccache 
DFSCOERC... meereen.essos.local 445    MEEREEN          VULNERABLE
DFSCOERC... meereen.essos.local 445    MEEREEN          Next step: https://github.com/Wh04m1001/DFSCoerce
```