### PR TITLE
Update masky module (v0.2.0)

### DIFF
--- a/cme/modules/masky.py
+++ b/cme/modules/masky.py
@@ -17,10 +17,13 @@ class CMEModule:
         CA              Certificate Authority Name (CA_SERVER\CA_NAME)
         TEMPLATE        Template name allowing users to authenticate with (default: User)
         DC_IP           IP Address of the domain controller
+        AGENT_EXE       Path to a custom executable masky agent to be deployed
         """
         self.template = "User"
         self.ca = None
         self.dc_ip = None
+        self.agent_exe = None
+        self.file_args = False
 
         if "CA" in module_options:
             self.ca = module_options["CA"]
@@ -30,6 +33,10 @@ class CMEModule:
 
         if "DC_IP" in module_options:
             self.dc_ip = module_options["DC_IP"]
+
+        if "AGENT_EXE" in module_options:
+            self.agent_exe = module_options["AGENT_EXE"]
+            self.file_args = True
 
     def on_admin_login(self, context, connection):
         if not self.ca:
@@ -55,6 +62,8 @@ class CMEModule:
             password=password,
             hashes=f"{lmhash}:{nthash}",
             kerberos=kerberos,
+            exe_path=self.agent_exe,
+            file_args=self.file_args,
         )
 
         context.log.info("Running Masky on the targeted host")
@@ -114,8 +123,8 @@ class CMEModule:
             context.log.error("Fail to clean files related to Masky")
             context.log.error(
                 (
-                    f"Please remove the files named '{tracker.agent_filename}', '{tracker.error_filename}'"
-                    f" & '{tracker.output_filename}' within the folder '\\Windows\\Temp\\'"
+                    f"Please remove the files named '{tracker.agent_filename}', '{tracker.error_filename}', "
+                    f"'{tracker.output_filename}' & '{tracker.args_filename}' within the folder '\\Windows\\Temp\\'"
                 )
             )
             ret = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ aioconsole = "^0.3.3"
 pywerview = "^0.3.3"
 minikerberos = "0.3.5"
 aardwolf = "0.2.5"
-masky = "^0.1.1"
+masky = "^0.2.0"
 
 [tool.poetry.dev-dependencies]
 flake8 = "*"


### PR DESCRIPTION
Hey!

I updated the Masky module with its new v0.2.0 version.

In short: bug fixes on the certificate request library (thanks to certipy v4.3.0) and a new feature to easily pack the agent executable ("AGENT_EXE").

![kali_DZNOq0ior0](https://user-images.githubusercontent.com/4901865/218589200-b1401e44-2829-468e-9a02-7e9716059cb0.png)

Let me know if I need to modify anything ;)