### PR TITLE
CMEDB: Export Signing

### DIFF
--- a/cme/cmedb.py
+++ b/cme/cmedb.py
@@ -223,6 +223,10 @@ class DatabaseNavigator(cmd.Cmd):
             
             # Detailed will generate 
             elif line[1].lower() == 'detailed':
+                """
+                Will Return a CSV file with details about all hosts
+                Its is essentially the exact same as export hosts detailed.... I don't know what else to do with this part.
+                """
                 csv_header = ["id","ip","hostname","domain","os","dc","smbv1","signing"]
                 hosts = self.db.get_smbsign_computers("detailed")
                 self.write_csv(filename,csv_header,hosts)
@@ -245,6 +249,9 @@ class DatabaseNavigator(cmd.Cmd):
                 csvFile.writerow(entry)
     
     def write_list(self,entries,filename):
+        """
+        Writes a fire with a simple list
+        """
         with open(os.path.expanduser(filename),"w") as export_file:
             for line in entries:
                 export_file.write(line+"\n")
@@ -299,7 +306,7 @@ class DatabaseNavigator(cmd.Cmd):
     def complete_export(self, text, line, begidx, endidx):
         "Tab-complete 'creds' commands."
 
-        commands = ["creds", "plaintext", "hashes"]
+        commands = ["creds", "plaintext", "hashes","shares","local_admins","signing"]
 
         mline = line.partition(' ')[2]
         offs = len(mline) - len(text)

--- a/cme/cmedb.py
+++ b/cme/cmedb.py
@@ -204,9 +204,35 @@ class DatabaseNavigator(cmd.Cmd):
                     
                 self.write_csv(filename,csv_header,formattedLocalAdmins)
                 print('[+] Local Admins exported')
-                     
+
+        elif line[0].lower() == 'signing':
+            if len(line) < 3:
+                print("[-] invalid arguments, export smb_signing <simple|detailed> <filename>")
+                return
+            filename = line[2]
+            
+
+            # Simple will just generate a list of IPs with SMB signing off.
+            if line[1].lower() == 'simple':
+                hosts = []
+                for i in self.db.get_smbsign_computers("simple"):
+                    hosts.append(i[0])
+                self.write_list(hosts,filename)
+                return
+                
+            
+            # Detailed will generate 
+            elif line[1].lower() == 'detailed':
+                csv_header = ["id","ip","hostname","domain","os","dc","smbv1","signing"]
+                hosts = self.db.get_smbsign_computers("detailed")
+                self.write_csv(filename,csv_header,hosts)
+                return
+
+
+
+
         else:
-            print('[-] invalid argument, specify creds, hosts, local_admins or shares')
+            print('[-] invalid argument, specify creds, hosts, local_admins, shares, or signing')
             
     def write_csv(self,filename,headers,entries):
         """
@@ -217,6 +243,13 @@ class DatabaseNavigator(cmd.Cmd):
             csvFile.writerow(headers)
             for entry in entries:
                 csvFile.writerow(entry)
+    
+    def write_list(self,entries,filename):
+        with open(os.path.expanduser(filename),"w") as export_file:
+            for line in entries:
+                export_file.write(line+"\n")
+        return
+
         
     def do_import(self, line):
         if not line:

--- a/cme/cmedb.py
+++ b/cme/cmedb.py
@@ -250,7 +250,7 @@ class DatabaseNavigator(cmd.Cmd):
     
     def write_list(self,entries,filename):
         """
-        Writes a fire with a simple list
+        Writes a file with a simple list
         """
         with open(os.path.expanduser(filename),"w") as export_file:
             for line in entries:

--- a/cme/protocols/smb/database.py
+++ b/cme/protocols/smb/database.py
@@ -537,3 +537,22 @@ class database:
         cur.close()
         logging.debug('get_groups(filterTerm={}, groupName={}, groupDomain={}) => {}'.format(filterTerm, groupName, groupDomain, results))
         return results
+
+    def get_smbsign_computers(self,version="simple"):
+        """
+        Retrun computers with SMB Signing off
+        version:
+            simple - Just IPs
+            detailed - Full Details from the Data Base
+        """
+        cur = self.conn.cursor()
+        if version == "simple":
+            cur.execute("SELECT ip FROM computers where signing=0")
+            
+        elif version == "detailed":
+            cur.execute("SELECT * FROM computers WHERE signing=0")
+        
+        
+        results = cur.fetchall()
+        cur.close
+        return results


### PR DESCRIPTION
Per a discord request by ad0nis:
Added a cmedb export feature for "signing".

`export signing simple <filename>` will export a list of IPs with SMB signing off.
`export signing detailed <filename>` will export the exact same thing as `export hosts detailed <filename>` because I can't think of what else to do with.

This feature will be useful for when you forget to add `--gen-relay <filename>` in your initial scan.