### PR TITLE
Fixing AttributeError: 'NoneType' object has no attribute 'error' whi…

### DIFF
--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -570,7 +570,8 @@ class smb(connection):
             self.smbv1 = False
         except socket.error as e:
             if str(e).find('Too many open files') != -1:
-                self.logger.error('SMBv3 connection error on {}: {}'.format(self.host if not kdc else kdc, e))
+                if not logger is None:
+                    self.logger.error('SMBv3 connection error on {}: {}'.format(self.host if not kdc else kdc, e))
             return False
         except (Exception, NetBIOSTimeout) as e:
             logging.debug('Error creating SMBv3 connection to {}: {}'.format(self.host if not kdc else kdc, e))


### PR DESCRIPTION
The following crash occurs when running out of file handles (related to the ulimit-discussion in issue #489)

> Traceback (most recent call last):                                                                                                                                                                                                          
>   File "/home/maraud3r/.cache/pypoetry/virtualenvs/crackmapexec-MRXVD3-M-py3.10/lib/python3.10/site-packages/impacket/nmb.py", line 899, in _setup_connection                                                                               
>     sock = socket.socket(af, socktype, proto)                                                                                                                                                                                               
>   File "/usr/lib/python3.10/socket.py", line 232, in __init__                                                                                                                                                                               
>     _socket.socket.__init__(self, family, type, proto, fileno)                     
> OSError: [Errno 24] Too many open files                                                                                                                                                                                                     
>                                                                                                                                                                                                                                             
> During handling of the above exception, another exception occurred:                                                                                                                                                                         
>                                                                                                                       
> Traceback (most recent call last):                                                                                                                                                                                                          
>   File "/home/maraud3r/GIT/CrackMapExec/cme/protocols/smb.py", line 571, in create_smbv3_conn                                                                                                                                               
>     self.conn = SMBConnection(self.host if not kdc else kdc, self.host if not kdc else kdc, None, self.args.port, timeout=self.args.smb_timeout)                                                                                            
>   File "/home/maraud3r/.cache/pypoetry/virtualenvs/crackmapexec-MRXVD3-M-py3.10/lib/python3.10/site-packages/impacket/smbconnection.py", line 80, in __init__                                                                               
>     self.negotiateSession(preferredDialect)                                                                                                                                                                                                 
>   File "/home/maraud3r/.cache/pypoetry/virtualenvs/crackmapexec-MRXVD3-M-py3.10/lib/python3.10/site-packages/impacket/smbconnection.py", line 120, in negotiateSession                                                                      
>     packet = self.negotiateSessionWildcard(self._myName, self._remoteName, self._remoteHost, self._sess_port,                                                                                                                               
>   File "/home/maraud3r/.cache/pypoetry/virtualenvs/crackmapexec-MRXVD3-M-py3.10/lib/python3.10/site-packages/impacket/smbconnection.py", line 169, in negotiateSessionWildcard                                                              
>     self._nmbSession = nmb.NetBIOSTCPSession(myName, remoteName, remoteHost, nmb.TYPE_SERVER, sess_port,                                                                                                                                    
>   File "/home/maraud3r/.cache/pypoetry/virtualenvs/crackmapexec-MRXVD3-M-py3.10/lib/python3.10/site-packages/impacket/nmb.py", line 893, in __init__                                                                                        
>     NetBIOSSession.__init__(self, myname, remote_name, remote_host, remote_type=remote_type, sess_port=sess_port,     
>   File "/home/maraud3r/.cache/pypoetry/virtualenvs/crackmapexec-MRXVD3-M-py3.10/lib/python3.10/site-packages/impacket/nmb.py", line 753, in __init__                                                                                        
>     self._sock = self._setup_connection((remote_host, sess_port), timeout)                                            
>   File "/home/maraud3r/.cache/pypoetry/virtualenvs/crackmapexec-MRXVD3-M-py3.10/lib/python3.10/site-packages/impacket/nmb.py", line 905, in _setup_connection                                                                               
>     raise socket.error("Connection error (%s:%s)" % (peer[0], peer[1]), e)                                                                                                                                                                  
> OSError: [Errno Connection error (5.136.20.14:445)] [Errno 24] Too many open files                                                                                                                                                          
>                                                            
> During handling of the above exception, another exception occurred:                                                   
>                                                                                                                                                                                                                                             
> Traceback (most recent call last):                                                                                                                                                                                                          
>   File "<string>", line 1, in <module>                                                                                                                                                                                                      
>   File "/home/maraud3r/GIT/CrackMapExec/cme/crackmapexec.py", line 257, in main                                       
>     asyncio.run(                                                                                                                                                                                                                            
>   File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run                                                                                                                                                                            
>     return loop.run_until_complete(main)                                                                              
>   File "/usr/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete                                  
>     return future.result()                                                                                                                                                                                                                  
>   File "/home/maraud3r/GIT/CrackMapExec/cme/crackmapexec.py", line 105, in start_threadpool                           
>     await asyncio.gather(*jobs)                                                                                                                                                                                                             
>   File "/home/maraud3r/GIT/CrackMapExec/cme/crackmapexec.py", line 69, in run_protocol                                
>     await asyncio.wait_for(                                                                                           
>   File "/usr/lib/python3.10/asyncio/tasks.py", line 408, in wait_for                                                                                                                                                                        
>     return await fut                                                                                                                                                                                                                        
>   File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run                                            
>     result = self.fn(*self.args, **self.kwargs)                                                                                                                                                                                             
>   File "/home/maraud3r/GIT/CrackMapExec/cme/protocols/smb.py", line 143, in __init__                                  
>     connection.__init__(self, args, db, host)                                                                                                                                                                                               
>   File "/home/maraud3r/GIT/CrackMapExec/cme/connection.py", line 65, in __init__                                                                                                                                                            
>     self.proto_flow()                                                                                                 
>   File "/home/maraud3r/GIT/CrackMapExec/cme/connection.py", line 96, in proto_flow                                                                                                                                                          
>     if self.create_conn_obj():                                                                                                                                                                                                              
>   File "/home/maraud3r/GIT/CrackMapExec/cme/protocols/smb.py", line 585, in create_conn_obj                                                                                                                                                 
>     elif self.create_smbv3_conn(kdc):                                                                                                                                                                                                       
>   File "/home/maraud3r/GIT/CrackMapExec/cme/protocols/smb.py", line 574, in create_smbv3_conn                         
>     self.logger.error('SMBv3 connection error on {}: {}'.format(self.host if not kdc else kdc, e))                    
> AttributeError: 'NoneType' object has no attribute 'error'            

This little fix will allow cme to keep running.
