### PR TITLE
Added option to check if wdigest is enabled without editing registry key

### DIFF
--- a/cme/modules/wdigest.py
+++ b/cme/modules/wdigest.py
@@ -16,14 +16,14 @@ class CMEModule:
 
     def options(self, context, module_options):
         '''
-            ACTION  Create/Delete the registry key (choices: enable, disable)
+            ACTION  Create/Delete the registry key (choices: enable, disable, check)
         '''
 
         if not 'ACTION' in module_options:
             context.log.error('ACTION option not specified!')
             exit(1)
 
-        if module_options['ACTION'].lower() not in ['enable', 'disable']:
+        if module_options['ACTION'].lower() not in ['enable', 'disable', 'check']:
             context.log.error('Invalid value for ACTION option!')
             exit(1)
 
@@ -34,6 +34,8 @@ class CMEModule:
             self.wdigest_enable(context, connection.conn)
         elif self.action == 'disable':
             self.wdigest_disable(context, connection.conn)
+        elif self.action == 'check':
+            self.wdigest_check(context, connection.conn)
 
     def wdigest_enable(self, context, smbconnection):
         remoteOps = RemoteOperations(smbconnection, False)
@@ -92,3 +94,29 @@ class CMEModule:
                 except:
                     pass
 
+    def wdigest_check(self, context, smbconnection):
+        remoteOps = RemoteOperations(smbconnection, False)
+        remoteOps.enableRegistry()
+
+        if remoteOps._RemoteOperations__rrp:
+            ans = rrp.hOpenLocalMachine(remoteOps._RemoteOperations__rrp)
+            regHandle = ans['phKey']
+
+            ans = rrp.hBaseRegOpenKey(remoteOps._RemoteOperations__rrp, regHandle, 'SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\WDigest')
+            keyHandle = ans['phkResult']
+
+            try:
+                rtype, data = rrp.hBaseRegQueryValue(remoteOps._RemoteOperations__rrp, keyHandle, 'UseLogonCredential\x00')
+                if int(data) == 1:
+                    context.log.success('UseLogonCredential registry key is enabled')
+                else:
+                    context.log.error('Unexpected registry value for UseLogonCredential: %s' % data)
+            except DCERPCException as d:
+                if 'winreg.HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\WDigest' in str(d):
+                    context.log.error('UseLogonCredential registry key is disabled (registry key not found)')
+                else:
+                    context.log.error('UseLogonCredential registry key not present')
+            try:
+                remoteOps.finish()
+            except:
+                pass


### PR DESCRIPTION
Added an option to check if WDigest is enabled on target hosts without editing registry keys. 

Needed this feature on a project in order to make a list of hosts that had WDigest enabled without editing the registry keys.

![wdigest](https://github.com/Porchetta-Industries/CrackMapExec/assets/52969604/26044870-06eb-4fa3-a162-348de55dc568)
