### PR TITLE
SSH: try upgrade to root using sudo

### DIFF
--- a/cme/protocols/ssh.py
+++ b/cme/protocols/ssh.py
@@ -101,7 +101,7 @@ class ssh(connection):
             return False
 
     def try_root_exec(self):
-        stdin, stdout, _ = self.conn.exec_command(f"sudo {self.args.execute}", get_pty=True)
+        stdin, stdout, _ = self.conn.exec_command(f"sudo -k -- sh -c '{self.args.execute}'", get_pty=True)
         stdin.write(f"{self.successful_password}\n")
         stdin.flush()
         return stdout


### PR DESCRIPTION
Many SSH-supporting systems (e.g. Debian and Ubuntu based Linux distributions) do not have a root password set by default, nor do their default SSH configurations support logging in as root. However, we can still execute commands as root by using sudo, usually with the user password of the user we're logged into if it's a sudoer.

This PR adds support for testing if we can do the root upgrade with the user we logged in with, and if executing a command, prefixing that command with sudo to execute it as root if requested. Modes include `--try-root-upgrade` (execute with sudo if possible, but fall back to executing as user if not possible) and `--force-root-upgrade` (execute a command if we have root, don't execute at all otherwise).