### PR TITLE
Fixes and Improvements

### DIFF
--- a/cme/helpers/bloodhound.py
+++ b/cme/helpers/bloodhound.py
@@ -28,12 +28,12 @@ def add_user_bh(user, domain, logger, config):
                             account_type = 'User'
 
                         result = tx.run(
-                            "MATCH (c:{} {{name:\"{}\"}}) RETURN c".format(account_type, user_owned))
+                            "MATCH (c:{}) where c.name =~ \"{}.*\" RETURN c".format(account_type, user_owned))
 
                         if result.data()[0]['c'].get('owned') in (False, None):
-                            logger.debug("MATCH (c:{} {{name:\"{}\"}}) SET c.owned=True RETURN c.name AS name".format(account_type, user_owned))
+                            logger.debug("MATCH (c:{}) where c.name =~ \"{}.*\" SET c.owned=True RETURN c.name AS name".format(account_type, user_owned))
                             result = tx.run(
-                                "MATCH (c:{} {{name:\"{}\"}}) SET c.owned=True RETURN c.name AS name".format(account_type, user_owned))
+                                "MATCH (c:{}) where c.name =~ \"{}.*\" SET c.owned=True RETURN c.name AS name".format(account_type, user_owned))
                             logger.highlight("Node {} successfully set as owned in BloodHound".format(user_owned))
         except AuthError as e:
             logger.error(

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -569,8 +569,9 @@ class smb(connection):
             self.conn = SMBConnection(self.host if not kdc else kdc, self.host if not kdc else kdc, None, self.args.port, timeout=self.args.smb_timeout)
             self.smbv1 = False
         except socket.error as e:
-            if str(e).find('Too many open files') != -1:
-                self.logger.error('SMBv3 connection error on {}: {}'.format(self.host if not kdc else kdc, e))
+            if str(e).find('Too many open files') != -1: #OSError: [Errno 24] Too many open files
+                if not logger is None: 
+                    self.logger.error('SMBv3 connection error on {}: {}'.format(self.host if not kdc else kdc, e))                    
             return False
         except (Exception, NetBIOSTimeout) as e:
             logging.debug('Error creating SMBv3 connection to {}: {}'.format(self.host if not kdc else kdc, e))

--- a/cme/protocols/smb.py
+++ b/cme/protocols/smb.py
@@ -594,15 +594,19 @@ class smb(connection):
         except:
             pass
         else:
-            dce.bind(scmr.MSRPC_UUID_SCMR)
             try:
-                # 0xF003F - SC_MANAGER_ALL_ACCESS
-                # http://msdn.microsoft.com/en-us/library/windows/desktop/ms685981(v=vs.85).aspx
-                ans = scmr.hROpenSCManagerW(dce,'{}\x00'.format(self.host),'ServicesActive\x00', 0xF003F)
-                self.admin_privs = True
-            except scmr.DCERPCException as e:
-                self.admin_privs = False
+                dce.bind(scmr.MSRPC_UUID_SCMR)
+            except:
                 pass
+            else:
+                try:
+                    # 0xF003F - SC_MANAGER_ALL_ACCESS
+                    # http://msdn.microsoft.com/en-us/library/windows/desktop/ms685981(v=vs.85).aspx
+                    ans = scmr.hROpenSCManagerW(dce,'{}\x00'.format(self.host),'ServicesActive\x00', 0xF003F)
+                    self.admin_privs = True
+                except scmr.DCERPCException as e:
+                    self.admin_privs = False
+                    pass
         return
 
     def gen_relay_list(self):


### PR DESCRIPTION
- aab54dda92f21e61f0edf7c3bd09268fbf01f144: Fixing a major flaw in the hash_spider module where it was not saving hashes to cmedb. I have implemented the structure from the lsassy module to resolve this issue.

- 32e57cf60adb088fac62c034647f92e75ff24d18 #252: I also encountered the same problem mentioned in issue #252. It seems that we encounter this error on unsupported SMB versions (likely non-Windows devices such as NAS). This error was causing the program to exit completely when running cme with a list. Therefore, I thought it would be a good idea to add a try-catch block to handle this scenario.

- cc78daa3fc328a5bf8f27040b4b215c656d8cffa #489: When facing the issue mentioned in #489, increasing ulimit -n and ulimit -u, along with this fix, prevented me from encountering the mentioned error.

- f2181343fb7c257f3c2af506dea87697aac3b243: Lastly, when performing a login without providing the full FQDN (e.g., DOMAIN/USER. not DOMAIN.LOCAL/USER), it was giving an error similar to #529. Therefore, I found it appropriate to add a regex match in the query for Neo4j to ensure compatibility. Of course, the full FQDN can still be used in query, but I'm not certain if BloodHound always adds it to Neo4j.
